### PR TITLE
Refactor API URL handling in AuthContext and useSocket hooks

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -234,7 +234,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     try {
-      const response = await fetch("http://localhost:3000/auth/profile", {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+      const response = await fetch(`${apiUrl}/auth/profile`, {
         method: "PUT",
         headers: {
           Authorization: `Bearer ${tokens.accessToken}`,

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -19,7 +19,7 @@ export const useSocket = (jobId?: string, handlers?: SocketEventHandlers) => {
 
     useEffect(() => {
         // Create socket connection
-        const newSocket = io('http://localhost:3000', {
+        const newSocket = io(process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000', {
             transports: ['websocket', 'polling'],
         });
 


### PR DESCRIPTION
- Updated AuthContext to dynamically fetch the API URL from environment variables, defaulting to localhost if not set, enhancing flexibility for different environments.
- Modified useSocket hook to use the same dynamic API URL for socket connections, ensuring consistency across the application.