### PR TITLE
Add preview monitoring client tracking and admin dashboard.

### DIFF
--- a/src/app/preview/[id]/analytics/page.tsx
+++ b/src/app/preview/[id]/analytics/page.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  Button,
+  Card,
+  Empty,
+  Select,
+  Spin,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { ArrowLeftOutlined, ReloadOutlined } from "@ant-design/icons";
+import { apiClient, PreviewAnalyticsReport } from "@/lib/api";
+import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import SidebarLayout from "@/components/layout/SidebarLayout";
+import { useAuth } from "@/contexts/AuthContext";
+import { canPerformAdminActions } from "@/utils/roleUtils";
+import moment from "moment";
+
+const { Text, Title } = Typography;
+
+function formatEventLabel(type: string) {
+  const labels: Record<string, string> = {
+    preview_visit: "Preview visit",
+    well_view: "Well viewed",
+    wellbore_open: "Diagram opened",
+    wellbore_fullscreen: "Fullscreen / tab",
+    wellbore_print: "Print view",
+  };
+  return labels[type] || type;
+}
+
+export default function PreviewAnalyticsPage() {
+  const params = useParams();
+  const previewId = params?.id as string;
+  const { user } = useAuth();
+  const isAdmin = canPerformAdminActions(user);
+
+  const [days, setDays] = useState(30);
+  const [report, setReport] = useState<PreviewAnalyticsReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!previewId) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await apiClient.getPreviewAnalytics(previewId, {
+        days,
+        sessionLimit: 75,
+        eventLimit: 150,
+      });
+      if (res.success && res.data) {
+        setReport(res.data);
+      } else {
+        setError(res.message || "Failed to load analytics");
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to load analytics");
+    } finally {
+      setLoading(false);
+    }
+  }, [previewId, days]);
+
+  useEffect(() => {
+    if (isAdmin) load();
+  }, [isAdmin, load]);
+
+  const topWellColumns: ColumnsType<PreviewAnalyticsReport["topWells"][0]> = [
+    {
+      title: "Well / file",
+      dataIndex: "well_label",
+      key: "well_label",
+      ellipsis: true,
+    },
+    {
+      title: "Views",
+      dataIndex: "view_count",
+      key: "view_count",
+      width: 80,
+      sorter: (a, b) => a.view_count - b.view_count,
+    },
+    {
+      title: "Unique visitors",
+      dataIndex: "unique_sessions",
+      key: "unique_sessions",
+      width: 120,
+    },
+    {
+      title: "Last viewed",
+      dataIndex: "last_viewed_at",
+      key: "last_viewed_at",
+      width: 160,
+      render: (v: string) => moment(v).format("MMM D, HH:mm"),
+    },
+  ];
+
+  const sessionColumns: ColumnsType<PreviewAnalyticsReport["sessions"][0]> = [
+    {
+      title: "Last seen",
+      dataIndex: "last_seen_at",
+      key: "last_seen_at",
+      width: 150,
+      render: (v: string) => moment(v).format("MMM D, HH:mm"),
+    },
+    {
+      title: "IP",
+      dataIndex: "ip_address",
+      key: "ip_address",
+      width: 130,
+      render: (v: string | null, row) => (
+        <span title={row.user_agent || undefined}>{v || "—"}</span>
+      ),
+    },
+    {
+      title: "Location",
+      key: "location",
+      width: 100,
+      render: (_, row) => {
+        const parts = [row.country_code, row.region].filter(Boolean);
+        return parts.length ? parts.join(" · ") : "—";
+      },
+    },
+    {
+      title: "Events",
+      dataIndex: "event_count",
+      key: "event_count",
+      width: 72,
+    },
+    {
+      title: "Wellbore",
+      dataIndex: "wellbore_event_count",
+      key: "wellbore_event_count",
+      width: 88,
+      render: (n: number) =>
+        n > 0 ? <Tag color="blue">{n}</Tag> : <Text type="secondary">0</Text>,
+    },
+    {
+      title: "First seen",
+      dataIndex: "first_seen_at",
+      key: "first_seen_at",
+      width: 150,
+      render: (v: string) => moment(v).format("MMM D, HH:mm"),
+    },
+  ];
+
+  const eventColumns: ColumnsType<PreviewAnalyticsReport["recentEvents"][0]> = [
+    {
+      title: "When",
+      dataIndex: "created_at",
+      key: "created_at",
+      width: 150,
+      render: (v: string) => moment(v).format("MMM D, HH:mm:ss"),
+    },
+    {
+      title: "Event",
+      dataIndex: "event_type",
+      key: "event_type",
+      width: 140,
+      render: (t: string) => formatEventLabel(t),
+    },
+    {
+      title: "Well",
+      dataIndex: "well_label",
+      key: "well_label",
+      ellipsis: true,
+      render: (v: string | null) => v || "—",
+    },
+    {
+      title: "IP",
+      dataIndex: "ip_address",
+      key: "ip_address",
+      width: 120,
+      render: (v: string | null, row) => (
+        <span>
+          {v || "—"}
+          {row.country_code ? ` (${row.country_code})` : ""}
+        </span>
+      ),
+    },
+  ];
+
+  if (!isAdmin) {
+    return (
+      <ProtectedRoute>
+        <SidebarLayout pageTitle="Preview monitoring">
+          <Empty description="Admin access required" />
+        </SidebarLayout>
+      </ProtectedRoute>
+    );
+  }
+
+  return (
+    <ProtectedRoute>
+      <SidebarLayout
+        pageTitle="Preview monitoring"
+        headerActions={
+          <div className="flex items-center gap-2">
+            <Select
+              size="small"
+              value={days}
+              onChange={setDays}
+              options={[
+                { value: 7, label: "Last 7 days" },
+                { value: 30, label: "Last 30 days" },
+                { value: 90, label: "Last 90 days" },
+              ]}
+              style={{ width: 130 }}
+            />
+            <Button
+              size="small"
+              icon={<ReloadOutlined />}
+              onClick={load}
+              loading={loading}
+            >
+              Refresh
+            </Button>
+            {report?.preview && (
+              <Link href={`/preview/${previewId}`} target="_blank">
+                <Button size="small" type="link">
+                  Open preview
+                </Button>
+              </Link>
+            )}
+          </div>
+        }
+      >
+        <div className="max-w-6xl mx-auto space-y-4 p-4">
+          <Link
+            href="/files"
+            className="inline-flex items-center text-sm text-gray-600 hover:text-gray-900"
+          >
+            <ArrowLeftOutlined className="mr-1" /> Back
+          </Link>
+
+          {report?.preview && (
+            <div>
+              <Title level={4} className="!mb-0">
+                {report.preview.name}
+              </Title>
+              <Text type="secondary" className="text-xs font-mono">
+                {report.preview.id}
+              </Text>
+            </div>
+          )}
+
+          {loading && !report ? (
+            <div className="flex justify-center py-16">
+              <Spin size="large" />
+            </div>
+          ) : error ? (
+            <Empty description={error} />
+          ) : report ? (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                <Card size="small">
+                  <Statistic
+                    title="Unique visitors"
+                    value={report.summary.uniqueSessions}
+                  />
+                </Card>
+                <Card size="small">
+                  <Statistic
+                    title="Preview visits"
+                    value={report.summary.previewVisits}
+                  />
+                </Card>
+                <Card size="small">
+                  <Statistic
+                    title="Wells viewed"
+                    value={report.summary.uniqueWellsViewed}
+                  />
+                </Card>
+                <Card size="small">
+                  <Statistic
+                    title="Wellbore usage"
+                    value={report.summary.wellboreAdoptionRate}
+                    suffix="%"
+                  />
+                  <Text type="secondary" className="text-xs">
+                    {report.summary.sessionsUsingWellbore} of{" "}
+                    {report.summary.uniqueSessions} sessions opened diagram
+                  </Text>
+                </Card>
+              </div>
+
+              {report.wellboreBreakdown.length > 0 && (
+                <Card size="small" title="Wellbore diagram actions">
+                  <div className="flex flex-wrap gap-2">
+                    {report.wellboreBreakdown.map((row) => (
+                      <Tag key={row.event_type}>
+                        {formatEventLabel(row.event_type)}: {row.count}
+                      </Tag>
+                    ))}
+                  </div>
+                </Card>
+              )}
+
+              <Card size="small" title="Most viewed wells">
+                <Table
+                  size="small"
+                  rowKey={(r) => `${r.job_file_id}-${r.well_label}`}
+                  columns={topWellColumns}
+                  dataSource={report.topWells}
+                  pagination={false}
+                  locale={{ emptyText: "No well views yet" }}
+                />
+              </Card>
+
+              <Card size="small" title="Visitors (sessions)">
+                <Table
+                  size="small"
+                  rowKey="id"
+                  columns={sessionColumns}
+                  dataSource={report.sessions}
+                  pagination={{ pageSize: 15, size: "small" }}
+                  scroll={{ x: 800 }}
+                />
+              </Card>
+
+              <Card size="small" title="Recent activity">
+                <Table
+                  size="small"
+                  rowKey="id"
+                  columns={eventColumns}
+                  dataSource={report.recentEvents}
+                  pagination={{ pageSize: 20, size: "small" }}
+                  scroll={{ x: 700 }}
+                />
+              </Card>
+            </>
+          ) : null}
+        </div>
+      </SidebarLayout>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
 } from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
 import { WellboreDiagramDrawer } from "@/components/well/WellboreDiagramModal";
+import { trackPreviewAnalytics } from "@/lib/previewAnalytics";
 
 // Styles for truncation and proper spacing
 const tableStyles = `
@@ -330,6 +331,18 @@ const PreviewPage: React.FC = () => {
                       setSelectedWellData(record);
                       setSelectedFilename(text);
                       setWellboreModalOpen(true);
+                      trackPreviewAnalytics(previewId, [
+                        {
+                          type: "wellbore_open",
+                          jobFileId: record._fileId,
+                          wellLabel: text,
+                        },
+                        {
+                          type: "well_view",
+                          jobFileId: record._fileId,
+                          wellLabel: text,
+                        },
+                      ]);
                     }}
                   />
                 </Tooltip>
@@ -604,6 +617,19 @@ const PreviewPage: React.FC = () => {
   useEffect(() => {
     fetchPreviewStatistics();
   }, [fetchPreviewStatistics]);
+
+  // Record preview page visit (once per browser session per preview)
+  useEffect(() => {
+    if (!previewId || loading) return;
+    const key = `preview_visit_tracked_${previewId}`;
+    try {
+      if (sessionStorage.getItem(key)) return;
+      sessionStorage.setItem(key, "1");
+    } catch {
+      /* sessionStorage unavailable */
+    }
+    trackPreviewAnalytics(previewId, [{ type: "preview_visit" }]);
+  }, [previewId, loading]);
 
   // Handle search input change with debouncing
   useEffect(() => {

--- a/src/app/wellbore/[id]/page.tsx
+++ b/src/app/wellbore/[id]/page.tsx
@@ -7,6 +7,7 @@ import { WellboreDiagram } from "@/components/well/WellboreDiagram";
 import { Button } from "antd";
 import { ArrowLeftOutlined, PrinterOutlined } from "@ant-design/icons";
 import Link from "next/link";
+import { trackPreviewAnalytics } from "@/lib/previewAnalytics";
 
 interface PreviewData {
   preview: PreviewDataTable;
@@ -94,6 +95,13 @@ const WellborePreviewContent: React.FC = () => {
         }
 
         setWellData(wellData);
+        trackPreviewAnalytics(previewId, [
+          {
+            type: "wellbore_fullscreen",
+            jobFileId: record.id,
+            wellLabel: filename || record.filename,
+          },
+        ]);
       } catch (err: any) {
         console.error("Error fetching well data:", err);
         setError(

--- a/src/app/wellbore/[id]/print/page.tsx
+++ b/src/app/wellbore/[id]/print/page.tsx
@@ -6,6 +6,7 @@ import { apiClient, PreviewJobFile } from "@/lib/api";
 import { WellboreDiagramPrint } from "@/components/well/WellboreDiagramPrint";
 import { Button } from "antd";
 import { ArrowLeftOutlined, PrinterOutlined } from "@ant-design/icons";
+import { trackPreviewAnalytics } from "@/lib/previewAnalytics";
 
 const WellborePrintContent: React.FC = () => {
   const params = useParams();
@@ -84,6 +85,13 @@ const WellborePrintContent: React.FC = () => {
         }
 
         setWellData(wellData);
+        trackPreviewAnalytics(previewId, [
+          {
+            type: "wellbore_print",
+            jobFileId: record.id,
+            wellLabel: filename || record.filename,
+          },
+        ]);
       } catch (err: any) {
         console.error("Error fetching well data:", err);
         setError(

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -1443,19 +1443,28 @@ const FileTable: React.FC<FileTableProps> = ({
             style={{ overflow: "hidden", whiteSpace: "nowrap" }}
           >
             {visiblePreviews.map((preview, index) => (
-              <a
-                key={preview.id}
-                href={`/preview/${preview.id}`}
-                target="_blank"
-                style={{
-                  color: "#1890ff",
-                  whiteSpace: "nowrap",
-                  flexShrink: 0,
-                }}
-              >
-                {preview.name}
+              <span key={preview.id} className="inline-flex items-center gap-0.5 shrink-0">
+                <a
+                  href={`/preview/${preview.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ color: "#1890ff", whiteSpace: "nowrap" }}
+                >
+                  {preview.name}
+                </a>
+                {isAdmin && (
+                  <a
+                    href={`/preview/${preview.id}/analytics`}
+                    target="_blank"
+                    rel="noreferrer"
+                    title="Preview monitoring"
+                    className="text-[10px] text-gray-400 hover:text-gray-700 ml-0.5"
+                  >
+                    stats
+                  </a>
+                )}
                 {index < visiblePreviews.length - 1 && ", "}
-              </a>
+              </span>
             ))}
             {remainingCount > 0 && (
               <Popover

--- a/src/components/well/WellboreDiagramModal.tsx
+++ b/src/components/well/WellboreDiagramModal.tsx
@@ -13,6 +13,7 @@ import { WellboreDiagram } from "./WellboreDiagram";
 // Import the interface from WellboreDiagram to ensure consistency
 import type { MGSWellData } from "./WellboreDiagram";
 import Link from "next/link";
+import { trackPreviewAnalytics } from "@/lib/previewAnalytics";
 
 // Re-export for backward compatibility
 export type { MGSWellData };
@@ -50,8 +51,25 @@ export const WellboreDiagramDrawer: React.FC<WellboreDiagramDrawerProps> = ({
       filename ? `?filename=${encodeURIComponent(filename)}` : ""
     }`;
 
-    // Open in new tab
     window.open(url, "_blank");
+    if (id) {
+      trackPreviewAnalytics(id, [
+        {
+          type: "wellbore_fullscreen",
+          wellLabel: filename,
+        },
+      ]);
+    }
+  };
+
+  const handlePrintClick = () => {
+    if (!previewId) return;
+    trackPreviewAnalytics(previewId, [
+      {
+        type: "wellbore_print",
+        wellLabel: filename,
+      },
+    ]);
   };
 
   return (
@@ -72,9 +90,10 @@ export const WellboreDiagramDrawer: React.FC<WellboreDiagramDrawerProps> = ({
           </Button>
           <Link
             href={`/wellbore/${previewId}/print?filename=${encodeURIComponent(
-              filename || ""
+              filename || "",
             )}`}
             target="_blank"
+            onClick={handlePrintClick}
           >
             <Button type="link" icon={<PrinterOutlined />} size="small">
               Print View

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -402,6 +402,51 @@ export interface PreviewJobFile {
     review_status?: 'pending' | 'in_review' | 'reviewed' | 'approved' | 'rejected';
 }
 
+export interface PreviewAnalyticsReport {
+    preview: { id: string; name: string };
+    periodDays: number;
+    since: string;
+    summary: {
+        uniqueSessions: number;
+        previewVisits: number;
+        wellViews: number;
+        wellboreEvents: number;
+        uniqueWellsViewed: number;
+        sessionsUsingWellbore: number;
+        wellboreAdoptionRate: number;
+    };
+    wellboreBreakdown: Array<{ event_type: string; count: number }>;
+    topWells: Array<{
+        well_label: string;
+        job_file_id: string | null;
+        view_count: number;
+        unique_sessions: number;
+        last_viewed_at: string;
+    }>;
+    sessions: Array<{
+        id: string;
+        client_session_id: string;
+        ip_address: string | null;
+        country_code: string | null;
+        region: string | null;
+        user_agent: string | null;
+        first_seen_at: string;
+        last_seen_at: string;
+        event_count: number;
+        wellbore_event_count: number;
+    }>;
+    recentEvents: Array<{
+        id: string;
+        event_type: string;
+        job_file_id: string | null;
+        well_label: string | null;
+        metadata: Record<string, unknown>;
+        created_at: string;
+        ip_address: string | null;
+        country_code: string | null;
+    }>;
+}
+
 class ApiClient {
     private baseURL: string;
     private accessToken: string | null = null;
@@ -1142,6 +1187,42 @@ class ApiClient {
         allVerified: boolean;
     }>> {
         return this.request(`/previews/${id}/statistics`);
+    }
+
+    async recordPreviewAnalyticsEvents(
+        previewId: string,
+        body: {
+            clientSessionId: string;
+            events: Array<{
+                type: string;
+                jobFileId?: string;
+                wellLabel?: string;
+                metadata?: Record<string, unknown>;
+            }>;
+        },
+    ): Promise<ApiResponse<{ sessionId: string; inserted: number }>> {
+        return this.request(`/previews/${previewId}/analytics/events`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+    }
+
+    async getPreviewAnalytics(
+        previewId: string,
+        params?: { days?: number; sessionLimit?: number; eventLimit?: number },
+    ): Promise<ApiResponse<PreviewAnalyticsReport>> {
+        const qs = new URLSearchParams();
+        if (params?.days != null) qs.set('days', String(params.days));
+        if (params?.sessionLimit != null) {
+            qs.set('sessionLimit', String(params.sessionLimit));
+        }
+        if (params?.eventLimit != null) {
+            qs.set('eventLimit', String(params.eventLimit));
+        }
+        const query = qs.toString();
+        return this.request(
+            `/previews/${previewId}/analytics${query ? `?${query}` : ''}`,
+        );
     }
 
     async createPreview(name: string, schema: any, logo?: string): Promise<ApiResponse<PreviewDataTable>> {

--- a/src/lib/previewAnalytics.ts
+++ b/src/lib/previewAnalytics.ts
@@ -1,0 +1,75 @@
+import { apiClient } from "@/lib/api";
+
+const SESSION_STORAGE_KEY = "preview_analytics_client_session";
+
+export type PreviewAnalyticsEventType =
+  | "preview_visit"
+  | "well_view"
+  | "wellbore_open"
+  | "wellbore_fullscreen"
+  | "wellbore_print";
+
+export interface PreviewAnalyticsEventPayload {
+  type: PreviewAnalyticsEventType;
+  jobFileId?: string;
+  wellLabel?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function getPreviewClientSessionId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    let id = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (!id) {
+      id =
+        typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `ps-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      sessionStorage.setItem(SESSION_STORAGE_KEY, id);
+    }
+    return id;
+  } catch {
+    return `ps-${Date.now()}`;
+  }
+}
+
+/** Fire-and-forget preview analytics (public preview pages). */
+export function trackPreviewAnalytics(
+  previewId: string,
+  events: PreviewAnalyticsEventPayload[],
+): void {
+  if (!previewId || events.length === 0) return;
+
+  const clientSessionId = getPreviewClientSessionId();
+  if (!clientSessionId) return;
+
+  void apiClient
+    .recordPreviewAnalyticsEvents(previewId, { clientSessionId, events })
+    .catch(() => {
+      /* non-blocking */
+    });
+}
+
+export function trackPreviewAnalyticsBeacon(
+  previewId: string,
+  events: PreviewAnalyticsEventPayload[],
+): void {
+  if (typeof navigator === "undefined" || !navigator.sendBeacon) {
+    trackPreviewAnalytics(previewId, events);
+    return;
+  }
+
+  const base =
+    process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+  const clientSessionId = getPreviewClientSessionId();
+  const body = JSON.stringify({ clientSessionId, events });
+
+  try {
+    navigator.sendBeacon(
+      `${base}/previews/${previewId}/analytics/events`,
+      new Blob([body], { type: "application/json" }),
+    );
+  } catch {
+    trackPreviewAnalytics(previewId, events);
+  }
+}


### PR DESCRIPTION
Record preview visits, well views, and wellbore actions from public preview pages; expose admin analytics view at /preview/[id]/analytics.