### PR TITLE
feat: Phase 6 — server-side search, filter & sort UI

### DIFF
--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -357,7 +357,14 @@ const FileTable: React.FC<FileTableProps> = ({
     const resetPage = filtersChanged || sortChanged;
 
     setTableParams({
-      pagination: resetPage ? { ...pagination, current: 1 } : pagination,
+      pagination: {
+        ...pagination,
+        pageSize:
+          pagination.pageSize ||
+          tableParams.pagination?.pageSize ||
+          DEFAULT_PAGE_SIZE,
+        ...(resetPage ? { current: 1 } : {}),
+      },
       filters,
       sortOrder: newSortOrder,
       sortField: newSortField,
@@ -2114,6 +2121,8 @@ const FileTable: React.FC<FileTableProps> = ({
       rowSelection={rowSelection}
       pagination={{
         ...tableParams.pagination,
+        showSizeChanger: true,
+        pageSizeOptions: ["10", "20", "50", "100"],
         showQuickJumper: true,
         showTotal: (total, range) =>
           `${range[0]}-${range[1]} of ${total} items`,

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -52,7 +52,7 @@ import {
 import FileDetailsDrawer from "@/components/file/FileDetailsDrawer";
 import FullscreenModal from "@/components/file/FullscreenModal";
 import styles from "./FileTable.module.css";
-import { Loader, MessageSquare } from "lucide-react";
+import { Loader, MessageSquare, SearchIcon } from "lucide-react";
 import { SignalIcon } from "@heroicons/react/24/outline";
 import StatusIndicator from "@/components/ui/StatusIndicator";
 
@@ -90,7 +90,11 @@ interface FileTableProps {
   onDataUpdate?: () => void;
   refreshTrigger?: number;
   /** Phase 2: server pushes row-level patches via socket */
-  filePatch?: { fileId: string; patch: Record<string, any>; version: string } | null;
+  filePatch?: {
+    fileId: string;
+    patch: Record<string, any>;
+    version: string;
+  } | null;
   fileSummary?: {
     total: number;
     extraction_pending: number;
@@ -276,9 +280,15 @@ const FileTable: React.FC<FileTableProps> = ({
         (pagination?.pageSize || DEFAULT_PAGE_SIZE);
 
       // Build Phase 6 filter params from Ant Design table filters
-      const extractionStatusFilter = filters?.extraction_status?.[0] as string | undefined;
-      const processingStatusFilter = filters?.processing_status?.[0] as string | undefined;
-      const reviewStatusFilter = filters?.review_status?.[0] as string | undefined;
+      const extractionStatusFilter = filters?.extraction_status?.[0] as
+        | string
+        | undefined;
+      const processingStatusFilter = filters?.processing_status?.[0] as
+        | string
+        | undefined;
+      const reviewStatusFilter = filters?.review_status?.[0] as
+        | string
+        | undefined;
 
       const response = await apiClient.getAllFiles(
         pagination?.pageSize || DEFAULT_PAGE_SIZE,
@@ -339,14 +349,15 @@ const FileTable: React.FC<FileTableProps> = ({
         : undefined;
 
     // Reset to page 1 when filters or sort change
-    const filtersChanged = JSON.stringify(filters) !== JSON.stringify(tableParams.filters);
-    const sortChanged = newSortField !== tableParams.sortField || newSortOrder !== tableParams.sortOrder;
+    const filtersChanged =
+      JSON.stringify(filters) !== JSON.stringify(tableParams.filters);
+    const sortChanged =
+      newSortField !== tableParams.sortField ||
+      newSortOrder !== tableParams.sortOrder;
     const resetPage = filtersChanged || sortChanged;
 
     setTableParams({
-      pagination: resetPage
-        ? { ...pagination, current: 1 }
-        : pagination,
+      pagination: resetPage ? { ...pagination, current: 1 } : pagination,
       filters,
       sortOrder: newSortOrder,
       sortField: newSortField,
@@ -1290,22 +1301,22 @@ const FileTable: React.FC<FileTableProps> = ({
         >
           {record.processing_status === "completed" &&
             ((record as any).has_result ?? record.result) && (
-            <>
-              <Tooltip title="View results">
-                <FullscreenOutlined
-                  style={{
-                    cursor: "pointer",
-                    color: "#1890ff",
-                    flexShrink: 0,
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleOpenFullscreen(record);
-                  }}
-                />
-              </Tooltip>
-            </>
-          )}
+              <>
+                <Tooltip title="View results">
+                  <FullscreenOutlined
+                    style={{
+                      cursor: "pointer",
+                      color: "#1890ff",
+                      flexShrink: 0,
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleOpenFullscreen(record);
+                    }}
+                  />
+                </Tooltip>
+              </>
+            )}
           <CopyOutlined
             style={{
               color: "#1890ff",
@@ -1359,7 +1370,8 @@ const FileTable: React.FC<FileTableProps> = ({
       key: "size",
       width: 100,
       sorter: true,
-      sortOrder: tableParams.sortField === "size" ? tableParams.sortOrder : undefined,
+      sortOrder:
+        tableParams.sortField === "size" ? tableParams.sortOrder : undefined,
       render: (size: number) => (
         <Text type="secondary" style={{ whiteSpace: "nowrap" }}>
           {formatFileSize(size)}
@@ -1401,7 +1413,10 @@ const FileTable: React.FC<FileTableProps> = ({
       key: "created_at",
       width: 150,
       sorter: true,
-      sortOrder: tableParams.sortField === "created_at" ? tableParams.sortOrder : undefined,
+      sortOrder:
+        tableParams.sortField === "created_at"
+          ? tableParams.sortOrder
+          : undefined,
       render: (date: string) => (
         <Text
           type="secondary"
@@ -1493,7 +1508,7 @@ const FileTable: React.FC<FileTableProps> = ({
     {
       title: "Review Status",
       key: "review_status",
-      width: 130,
+      // width: 130,
       filters: [
         { text: "Pending", value: "pending" },
         { text: "Approved", value: "approved" },
@@ -1590,7 +1605,10 @@ const FileTable: React.FC<FileTableProps> = ({
       filterMultiple: false,
       filteredValue: tableParams.filters?.processing_status || null,
       sorter: true,
-      sortOrder: tableParams.sortField === "processing_status" ? tableParams.sortOrder : undefined,
+      sortOrder:
+        tableParams.sortField === "processing_status"
+          ? tableParams.sortOrder
+          : undefined,
       render: (_: any, record: JobFile) => (
         <Tooltip
           title={
@@ -2008,7 +2026,7 @@ const FileTable: React.FC<FileTableProps> = ({
             value={searchText}
             onChange={(e) => handleSearchChange(e.target.value)}
             style={{ width: 200 }}
-            prefix={<span style={{ color: '#bfbfbf' }}>🔍</span>}
+            prefix={<SearchIcon className="w-4 h-4" />}
           />
           {onGoLive && (
             <Button

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -235,6 +235,24 @@ const FileTable: React.FC<FileTableProps> = ({
   const [data, setData] = useState<JobFile[]>([]);
 
   const [loading, setLoading] = useState(false);
+  // Phase 6: search text state (debounced before sending to server)
+  const [searchText, setSearchText] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(value);
+      // Reset to page 1 on search
+      setTableParams((prev) => ({
+        ...prev,
+        pagination: { ...prev.pagination, current: 1 },
+      }));
+    }, 400);
+  };
+
   const [tableParams, setTableParams] = useState<TableParams>({
     pagination: {
       current: 1,
@@ -242,7 +260,7 @@ const FileTable: React.FC<FileTableProps> = ({
     },
   });
 
-  // AJAX fetch function
+  // AJAX fetch function — Phase 6: passes search, filter & sort to server
   const fetchData = async () => {
     if (fetchAbortRef.current) {
       fetchAbortRef.current.abort();
@@ -252,17 +270,30 @@ const FileTable: React.FC<FileTableProps> = ({
 
     setLoading(true);
     try {
-      const { pagination } = tableParams;
+      const { pagination, sortField, sortOrder, filters } = tableParams;
       const offset =
         ((pagination?.current || 1) - 1) *
         (pagination?.pageSize || DEFAULT_PAGE_SIZE);
 
+      // Build Phase 6 filter params from Ant Design table filters
+      const extractionStatusFilter = filters?.extraction_status?.[0] as string | undefined;
+      const processingStatusFilter = filters?.processing_status?.[0] as string | undefined;
+      const reviewStatusFilter = filters?.review_status?.[0] as string | undefined;
+
       const response = await apiClient.getAllFiles(
         pagination?.pageSize || DEFAULT_PAGE_SIZE,
         offset,
-        undefined, // status filter
-        jobId, // jobId filter
+        undefined, // legacy status filter
+        jobId,
         controller.signal,
+        {
+          search: debouncedSearch || undefined,
+          extractionStatus: extractionStatusFilter,
+          processingStatus: processingStatusFilter,
+          reviewStatus: reviewStatusFilter,
+          sortField: sortField || undefined,
+          sortOrder: sortOrder || undefined,
+        },
       );
 
       setData(response.files || []);
@@ -288,25 +319,37 @@ const FileTable: React.FC<FileTableProps> = ({
 
   // Phase 3: mgsCountyByPermit fetch removed — flags now come from server
 
-  // Handle table change
+  // Handle table change — Phase 6: filters and sort are server-side
   const handleTableChange: TableProps<JobFile>["onChange"] = (
     pagination,
     filters,
     sorter,
   ) => {
+    const newSortField = Array.isArray(sorter)
+      ? undefined
+      : typeof sorter?.field === "string"
+        ? sorter.field
+        : typeof sorter?.columnKey === "string"
+          ? sorter.columnKey
+          : undefined;
+    const newSortOrder = Array.isArray(sorter)
+      ? undefined
+      : sorter?.order === "ascend" || sorter?.order === "descend"
+        ? sorter.order
+        : undefined;
+
+    // Reset to page 1 when filters or sort change
+    const filtersChanged = JSON.stringify(filters) !== JSON.stringify(tableParams.filters);
+    const sortChanged = newSortField !== tableParams.sortField || newSortOrder !== tableParams.sortOrder;
+    const resetPage = filtersChanged || sortChanged;
+
     setTableParams({
-      pagination,
+      pagination: resetPage
+        ? { ...pagination, current: 1 }
+        : pagination,
       filters,
-      sortOrder: Array.isArray(sorter)
-        ? undefined
-        : sorter?.order === "ascend" || sorter?.order === "descend"
-          ? sorter.order
-          : undefined,
-      sortField: Array.isArray(sorter)
-        ? undefined
-        : typeof sorter?.field === "string"
-          ? sorter.field
-          : undefined,
+      sortOrder: newSortOrder,
+      sortField: newSortField,
     });
 
     // Clear data when page size changes
@@ -802,6 +845,7 @@ const FileTable: React.FC<FileTableProps> = ({
     tableParams?.sortOrder,
     tableParams?.sortField,
     JSON.stringify(tableParams.filters),
+    debouncedSearch,
     refreshTrigger,
   ]);
 
@@ -1314,6 +1358,8 @@ const FileTable: React.FC<FileTableProps> = ({
       dataIndex: "size",
       key: "size",
       width: 100,
+      sorter: true,
+      sortOrder: tableParams.sortField === "size" ? tableParams.sortOrder : undefined,
       render: (size: number) => (
         <Text type="secondary" style={{ whiteSpace: "nowrap" }}>
           {formatFileSize(size)}
@@ -1354,6 +1400,8 @@ const FileTable: React.FC<FileTableProps> = ({
       dataIndex: "created_at",
       key: "created_at",
       width: 150,
+      sorter: true,
+      sortOrder: tableParams.sortField === "created_at" ? tableParams.sortOrder : undefined,
       render: (date: string) => (
         <Text
           type="secondary"
@@ -1446,6 +1494,15 @@ const FileTable: React.FC<FileTableProps> = ({
       title: "Review Status",
       key: "review_status",
       width: 130,
+      filters: [
+        { text: "Pending", value: "pending" },
+        { text: "Approved", value: "approved" },
+        { text: "Rejected", value: "rejected" },
+        { text: "In Review", value: "in_review" },
+        { text: "Reviewed", value: "reviewed" },
+      ],
+      filterMultiple: false,
+      filteredValue: tableParams.filters?.review_status || null,
       render: (_: any, record: JobFile) => {
         const status = record.review_status || "pending";
         const statusColors: Record<string, string> = {
@@ -1522,8 +1579,18 @@ const FileTable: React.FC<FileTableProps> = ({
     },
     {
       title: "Status",
-      key: "status",
+      key: "processing_status",
       width: 100,
+      filters: [
+        { text: "Pending", value: "pending" },
+        { text: "Processing", value: "processing" },
+        { text: "Completed", value: "completed" },
+        { text: "Failed", value: "failed" },
+      ],
+      filterMultiple: false,
+      filteredValue: tableParams.filters?.processing_status || null,
+      sorter: true,
+      sortOrder: tableParams.sortField === "processing_status" ? tableParams.sortOrder : undefined,
       render: (_: any, record: JobFile) => (
         <Tooltip
           title={
@@ -1933,6 +2000,16 @@ const FileTable: React.FC<FileTableProps> = ({
           </div>
         </div>
         <div className="flex items-center gap-2">
+          {/* Phase 6: Search input */}
+          <Input
+            placeholder="Search files..."
+            allowClear
+            size="small"
+            value={searchText}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            style={{ width: 200 }}
+            prefix={<span style={{ color: '#bfbfbf' }}>🔍</span>}
+          />
           {onGoLive && (
             <Button
               size="small"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1276,9 +1276,26 @@ class ApiClient {
         return this.request(`/previews/available-files?limit=${limit}`);
     }
 
-    async getAllFiles(limit: number = 50, offset: number = 0, status?: string, jobId?: string, signal?: AbortSignal): Promise<ApiResponse<{
+    async getAllFiles(
+        limit: number = 50,
+        offset: number = 0,
+        status?: string,
+        jobId?: string,
+        signal?: AbortSignal,
+        /** Phase 6: server-side search, filter & sort */
+        filters?: {
+            search?: string;
+            extractionStatus?: string;
+            processingStatus?: string;
+            reviewStatus?: string;
+            hasResult?: boolean;
+            sortField?: string;
+            sortOrder?: 'ascend' | 'descend';
+        },
+    ): Promise<ApiResponse<{
         files: JobFile[];
         total: number;
+        filteredTotal?: number;
         stats: {
             total: number;
             completed: number;
@@ -1302,6 +1319,15 @@ class ApiClient {
 
         if (status) params.append('status', status);
         if (jobId) params.append('jobId', jobId);
+
+        // Phase 6 params
+        if (filters?.search) params.append('search', filters.search);
+        if (filters?.extractionStatus) params.append('extractionStatus', filters.extractionStatus);
+        if (filters?.processingStatus) params.append('processingStatus', filters.processingStatus);
+        if (filters?.reviewStatus) params.append('reviewStatus', filters.reviewStatus);
+        if (filters?.hasResult != null) params.append('hasResult', String(filters.hasResult));
+        if (filters?.sortField) params.append('sortField', filters.sortField);
+        if (filters?.sortOrder) params.append('sortOrder', filters.sortOrder);
 
         return this.request(`/files?${params.toString()}`, { signal });
     }


### PR DESCRIPTION
## Summary
- Adds search input to file table toolbar (debounced 400ms, sends to server)
- Adds processing status filter dropdown on Status column (pending/processing/completed/failed)
- Adds review status filter dropdown on Review Status column
- Enables server-side sorting on Size, Created, and Status columns
- Resets to page 1 when search/filter/sort changes
- Updates `getAllFiles` API client to pass Phase 6 filter & sort params

## Test plan
- [x] Open a job page — file list loads normally
- [x] Type "permit" in search — only matching filenames shown
- [x] Clear search — full list returns
- [x] Click filter icon on Status column → select "Failed" — only failed files shown
- [x] Click "Created" column header — sorts ascending, click again for descending
- [x] Combine search + filter — both apply simultaneously, pagination updates
- [x] Change page size — still works with active filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)