### PR TITLE
Fix Ant Design message context warnings and improve page UX

### DIFF
--- a/src/app/files/page.tsx
+++ b/src/app/files/page.tsx
@@ -403,7 +403,7 @@ export default function FilesPage() {
   if (error) {
     return (
       <ProtectedRoute>
-        <SidebarLayout>
+        <SidebarLayout pageTitle="Files">
           <Card>
             <Empty description={error} image={Empty.PRESENTED_IMAGE_SIMPLE}>
               <Button type="primary" onClick={fetchFiles}>

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -11,7 +11,7 @@ import React, {
 } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
-import { Drawer, Dropdown, Modal, message } from "antd";
+import { App, Drawer, Dropdown, Modal } from "antd";
 import Card, { CardHeader, CardTitle, CardContent } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
 import StatusIndicator from "@/components/ui/StatusIndicator";
@@ -43,6 +43,7 @@ import {
 import { Loader } from "lucide-react";
 
 function JobDetailPage() {
+  const { message } = App.useApp();
   const params = useParams();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -281,6 +281,10 @@ const PreviewPage: React.FC = () => {
   const [selectedWellData, setSelectedWellData] = useState<any>(null);
   const [selectedFilename, setSelectedFilename] = useState<string>("");
 
+  useEffect(() => {
+    document.title = previewData?.preview.name ?? "Preview";
+  }, [previewData?.preview.name]);
+
   // Extract columns from schema
   const columns: TableColumn[] = useMemo(() => {
     if (!previewData?.preview.schema?.properties) return [];

--- a/src/components/DocumentRoutingPanel.tsx
+++ b/src/components/DocumentRoutingPanel.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  App,
   Button,
   Empty,
   Collapse,
@@ -11,7 +12,6 @@ import {
   Space,
   Tag,
   Tooltip,
-  message,
 } from "antd";
 import {
   CheckCircleFilled,
@@ -244,6 +244,7 @@ export default function DocumentRoutingPanel({
   visualClassifierMeta,
   onSectionsUpdated,
 }: Props) {
+  const { message } = App.useApp();
   const sections = detectedSections?.sections ?? [];
   const pages = detectedSections?.pages ?? [];
 

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -206,6 +206,18 @@ const FileTable: React.FC<FileTableProps> = ({
   >([]);
   const viewerLoadedFileIdRef = useRef<string | null>(null);
   const fetchAbortRef = useRef<AbortController | null>(null);
+  const [copiedFileId, setCopiedFileId] = useState<string | null>(null);
+  const copyResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimeoutRef.current) {
+        clearTimeout(copyResetTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Reprocess options state
   const [reprocessOptions, setReprocessOptions] = useState({
@@ -1098,10 +1110,20 @@ const FileTable: React.FC<FileTableProps> = ({
     }),
   };
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text).then(() => {
-      // message.success("ID copied to clipboard");
-    });
+  const copyToClipboard = async (fileId: string) => {
+    try {
+      await navigator.clipboard.writeText(fileId);
+      setCopiedFileId(fileId);
+      if (copyResetTimeoutRef.current) {
+        clearTimeout(copyResetTimeoutRef.current);
+      }
+      copyResetTimeoutRef.current = setTimeout(() => {
+        setCopiedFileId((current) => (current === fileId ? null : current));
+        copyResetTimeoutRef.current = null;
+      }, 2000);
+    } catch {
+      message.error("Failed to copy file ID");
+    }
   };
 
   const handleRetryUpload = async () => {
@@ -1336,14 +1358,28 @@ const FileTable: React.FC<FileTableProps> = ({
                 </Tooltip>
               </>
             )}
-          <CopyOutlined
-            style={{
-              color: "#1890ff",
-              cursor: "pointer",
-              flexShrink: 0,
-            }}
-            onClick={() => copyToClipboard(id)}
-          />
+          <Tooltip title={copiedFileId === id ? "Copied!" : "Copy file ID"}>
+            {copiedFileId === id ? (
+              <CheckCircleOutlined
+                style={{
+                  color: "#52c41a",
+                  flexShrink: 0,
+                }}
+              />
+            ) : (
+              <CopyOutlined
+                style={{
+                  color: "#1890ff",
+                  cursor: "pointer",
+                  flexShrink: 0,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void copyToClipboard(id);
+                }}
+              />
+            )}
+          </Tooltip>
           <Text
             style={{
               whiteSpace: "nowrap",

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import type { GetProp, TableProps } from "antd";
 import {
+  App,
   Table,
   Tooltip,
   Badge,
@@ -10,7 +11,6 @@ import {
   Typography,
   Dropdown,
   Popover,
-  message,
   Modal,
   Upload,
   Button,
@@ -154,6 +154,7 @@ const FileTable: React.FC<FileTableProps> = ({
   jobStatus,
   getJobStatusColor,
 }) => {
+  const { message } = App.useApp();
   const { user } = useAuth();
   const isAdmin = canPerformAdminActions(user);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
@@ -1348,6 +1349,7 @@ const FileTable: React.FC<FileTableProps> = ({
               whiteSpace: "nowrap",
               overflow: "hidden",
               textOverflow: "ellipsis",
+              maxWidth: 150,
             }}
           >
             {record.filename}

--- a/src/components/InlineSchemaEditor.tsx
+++ b/src/components/InlineSchemaEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { message } from "antd";
+import { App } from "antd";
 import { apiClient } from "@/lib/api";
 import { JsonViewer } from "@/components/json";
 
@@ -31,6 +31,7 @@ const InlineSchemaEditor: React.FC<InlineSchemaEditorProps> = ({
   currentSchema,
   onSuccess,
 }) => {
+  const { message } = App.useApp();
   const initial = useMemo(() => initialText(currentSchema), [currentSchema]);
   const [text, setText] = useState<string>(initial);
   const [saving, setSaving] = useState(false);

--- a/src/components/JobConfigEditor.tsx
+++ b/src/components/JobConfigEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Modal, Form, Input, Select, message, Divider, Switch, Tag } from "antd";
+import { App, Modal, Form, Input, Select, Divider, Switch, Tag } from "antd";
 import { apiClient, DocumentTypeInfo, ProcessingConfig } from "@/lib/api";
 import {
   PROCESSING_METHODS,
@@ -37,6 +37,7 @@ export default function JobConfigEditor({
   currentConfig,
   onUpdate,
 }: JobConfigEditorProps) {
+  const { message } = App.useApp();
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
   const [selectedProcessingMethod, setSelectedProcessingMethod] = useState<

--- a/src/components/PageSelectionModal.tsx
+++ b/src/components/PageSelectionModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Modal, Checkbox, Button, Spin, message, Input } from "antd";
+import { App, Modal, Checkbox, Button, Spin, Input } from "antd";
 import PDFViewer from "./PDFViewer";
 
 interface PageSelectionModalProps {
@@ -19,6 +19,7 @@ const PageSelectionModal: React.FC<PageSelectionModalProps> = ({
   onClose,
   onConfirm,
 }) => {
+  const { message } = App.useApp();
   const [numPages, setNumPages] = useState<number | null>(null);
   const [selectedPages, setSelectedPages] =
     useState<number[]>(initialSelectedPages);

--- a/src/components/json/core/Toolbar.tsx
+++ b/src/components/json/core/Toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Button, Segmented, Space, Tooltip, message } from "antd";
+import { App, Button, Segmented, Space, Tooltip } from "antd";
 import {
   CopyOutlined,
   DownloadOutlined,
@@ -61,6 +61,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
   size = "small",
   extra,
 }) => {
+  const { message } = App.useApp();
   const includes = (item: ToolbarItem) => items.includes(item);
   const fileRef = React.useRef<HTMLInputElement>(null);
 

--- a/src/components/layout/SidebarLayout.tsx
+++ b/src/components/layout/SidebarLayout.tsx
@@ -88,6 +88,17 @@ export default function SidebarLayout({
   const [isDesktop, setIsDesktop] = useState(true);
   const userMenuRef = useRef<HTMLDivElement>(null);
 
+  const resolvedPageTitle =
+    pageTitle ||
+    mainNavigationItems.find((item) => item.href === pathname)?.name ||
+    (pathname === adminRegistryNavItem.href
+      ? adminRegistryNavItem.name
+      : undefined);
+
+  useEffect(() => {
+    document.title = resolvedPageTitle ?? "Core Extract";
+  }, [resolvedPageTitle]);
+
   useEffect(() => {
     const savedCollapseState = localStorage.getItem("sidebarCollapsed");
     if (savedCollapseState !== null) {

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -7,7 +7,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { jsonToCsv } from "@/lib/csvExport";
 import { MessageSquare } from "lucide-react";
-import { Button, Input, message, Typography } from "antd";
+import { App, Button, Input, Typography } from "antd";
 import { JsonViewer } from "@/components/json";
 import {
   isV2ResultEnvelope,
@@ -143,6 +143,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
   resultEnvelope,
   sectionResults,
 }) => {
+  const { message } = App.useApp();
   const [activeTab, setActiveTab] = useState<TabType>("results");
   const [markdownView, setMarkdownView] = useState<MarkdownViewType>("full");
   const [editableJson, setEditableJson] = useState<string>("");


### PR DESCRIPTION
## Summary
- Replace static `message` imports with `App.useApp()` across job-page components so toasts respect Ant Design theme context and stop console warnings.
- Sync browser tab titles for Jobs, Files, Schema registry (via `SidebarLayout`), and Preview pages (preview name when loaded).
- Add copy-to-clipboard feedback on the file table (green check + tooltip for 2s).

## Test plan
- [ ] Open job detail page, reprocess a file — no `[antd: message] Static function can not consume context` warning in console
- [ ] Verify/review/save in file viewer modal — toasts still appear correctly
- [ ] Check browser tab titles: `/jobs`, `/files`, `/registry`, `/preview/[id]`
- [ ] Click copy icon on a file row — icon turns green with "Copied!" tooltip, reverts after 2s
- [ ] Confirm job config update and schema editor toasts still work


Made with [Cursor](https://cursor.com)