### PR TITLE
feat: per-section verification UI

### DIFF
--- a/src/components/file/FileViewerRightPane.tsx
+++ b/src/components/file/FileViewerRightPane.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { Typography } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
-import type { JobFile } from "@/lib/api";
+import {
+  apiClient,
+  type JobFile,
+  type SectionVerification,
+  type SectionVerificationStatus,
+} from "@/lib/api";
 import TabbedDataViewer from "@/components/ui/TabbedDataViewer";
 import ConstraintErrorIcon from "@/components/ui/ConstraintErrorIcon";
 import DocumentRoutingPanel from "@/components/DocumentRoutingPanel";
@@ -75,6 +80,45 @@ export default function FileViewerRightPane({
   const routingBadge =
     hasRouting && sectionCount > 0 ? String(sectionCount) : undefined;
 
+  // Section verification state — seeded from file.section_verifications
+  // (attached by the backend), then kept in sync via optimistic updates.
+  const [sectionVerifications, setSectionVerifications] = useState<SectionVerification[]>(
+    file.section_verifications ?? []
+  );
+
+  // Re-sync when the file prop changes (user switches to a different file)
+  React.useEffect(() => {
+    setSectionVerifications(file.section_verifications ?? []);
+  }, [file.id, file.section_verifications]);
+
+  const handleSectionVerify = useCallback(
+    async (sectionResultId: string, status: SectionVerificationStatus, notes?: string) => {
+      const res = await apiClient.updateSectionVerification(file.id, sectionResultId, status, notes);
+      if (res.status === "success" && res.data) {
+        setSectionVerifications((prev) => {
+          const idx = prev.findIndex((v) => v.section_result_id === sectionResultId);
+          if (idx >= 0) {
+            const next = [...prev];
+            next[idx] = res.data as SectionVerification;
+            return next;
+          }
+          return [...prev, res.data as SectionVerification];
+        });
+      }
+    },
+    [file.id]
+  );
+
+  const handleBulkSectionVerify = useCallback(
+    async (sectionResultIds: string[], status: SectionVerificationStatus) => {
+      const res = await apiClient.bulkUpdateSectionVerifications(file.id, sectionResultIds, status);
+      if (res.status === "success" && res.data) {
+        setSectionVerifications(res.data as SectionVerification[]);
+      }
+    },
+    [file.id]
+  );
+
   return (
     <div className="flex flex-col h-full min-h-0 bg-white overflow-hidden">
       <div className="flex items-center justify-between px-3 border-b border-gray-200 bg-white flex-shrink-0">
@@ -134,6 +178,9 @@ export default function FileViewerRightPane({
                 resultEnvelope={file.extraction_metadata?.result_envelope}
                 sectionResults={file.extraction_metadata?.section_results}
                 detectedSections={file.detected_sections}
+                sectionVerifications={sectionVerifications}
+                onSectionVerify={handleSectionVerify}
+                onBulkSectionVerify={handleBulkSectionVerify}
                 className="h-full"
               />
             )}

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -12,6 +12,8 @@ import { JsonViewer } from "@/components/json";
 import {
   isV2ResultEnvelope,
   type SectionResult,
+  type SectionVerification,
+  type SectionVerificationStatus,
   type V2ResultEnvelope,
 } from "@/lib/api";
 
@@ -56,7 +58,25 @@ interface TabbedDataViewerProps {
   sectionResults?: SectionResult[];
   // Classifier sections — used as fallback for record_id and page_range when
   // section_results is missing (older extractions, extraction-only runs, etc.)
-  detectedSections?: { sections?: Array<{ document_type_slug: string; record_id?: string | null; page_range?: [number, number]; extraction_pages?: number[] }> } | null;
+  detectedSections?: {
+    sections?: Array<{
+      document_type_slug: string;
+      record_id?: string | null;
+      page_range?: [number, number];
+      extraction_pages?: number[];
+    }>;
+  } | null;
+  // Per-section verification
+  sectionVerifications?: SectionVerification[];
+  onSectionVerify?: (
+    sectionResultId: string,
+    status: SectionVerificationStatus,
+    notes?: string,
+  ) => Promise<void>;
+  onBulkSectionVerify?: (
+    sectionResultIds: string[],
+    status: SectionVerificationStatus,
+  ) => Promise<void>;
 }
 
 // One discoverable "row" in the section picker. We derive these from the
@@ -64,6 +84,7 @@ interface TabbedDataViewerProps {
 // working even when section_results is missing (older results, etc.).
 interface SectionPickerEntry {
   slug: string;
+  sectionResultId?: string;
   recordId?: string | null;
   instanceIndex: number; // 0-based index within slug
   globalIndex: number; // unique selection key
@@ -77,7 +98,14 @@ interface SectionPickerEntry {
 function buildSectionPickerEntries(
   envelope: V2ResultEnvelope,
   sectionResults?: SectionResult[],
-  detectedSections?: { sections?: Array<{ document_type_slug: string; record_id?: string | null; page_range?: [number, number]; extraction_pages?: number[] }> } | null,
+  detectedSections?: {
+    sections?: Array<{
+      document_type_slug: string;
+      record_id?: string | null;
+      page_range?: [number, number];
+      extraction_pages?: number[];
+    }>;
+  } | null,
 ): SectionPickerEntry[] {
   // Walk the envelope first (it's the ground truth for what data exists),
   // then enrich each entry with the matching section_results row when we can.
@@ -97,7 +125,10 @@ function buildSectionPickerEntries(
   // Fallback: use detected_sections for record_id and page_range when
   // section_results is missing (older extractions, extraction-only runs).
   // Group by slug in document order to match envelope ordering.
-  const detectedBySlug = new Map<string, Array<{ record_id?: string | null; page_range?: [number, number] }>>();
+  const detectedBySlug = new Map<
+    string,
+    Array<{ record_id?: string | null; page_range?: [number, number] }>
+  >();
   if (detectedSections?.sections) {
     for (const ds of detectedSections.sections) {
       if (!ds.document_type_slug || ds.document_type_slug === "none") continue;
@@ -115,14 +146,19 @@ function buildSectionPickerEntries(
     instances.forEach((data, instanceIndex) => {
       const sr = matching[instanceIndex];
       const ds = detectedMatching[instanceIndex];
+      const dataObj = data as Record<string, unknown>;
       entries.push({
         slug,
+        sectionResultId:
+          (dataObj?.section_result_id as string) ?? sr?.section_result_id,
         recordId: sr?.record_id ?? ds?.record_id ?? null,
         instanceIndex,
         globalIndex: globalIndex++,
-        data: data as Record<string, unknown>,
+        data: dataObj,
         fieldCount:
-          data && typeof data === "object" ? Object.keys(data as object).length : 0,
+          dataObj && typeof dataObj === "object"
+            ? Object.keys(dataObj).length
+            : 0,
         pageRange: sr?.page_range ?? ds?.page_range,
         status: sr?.status,
       });
@@ -162,6 +198,136 @@ function formatSectionOptionLabel(entry: SectionPickerEntry): string {
   return parts.join(" · ");
 }
 
+/* ── Verification status helpers ───────────────────────────────── */
+
+const VERIFY_STATUS_CONFIG: Record<
+  SectionVerificationStatus,
+  { label: string; icon: string; solidBg: string; solidText: string }
+> = {
+  pending: {
+    label: "Pending",
+    icon: "○",
+    solidBg: "bg-gray-100",
+    solidText: "text-gray-500",
+  },
+  in_review: {
+    label: "In Review",
+    icon: "◐",
+    solidBg: "bg-blue-100",
+    solidText: "text-blue-700",
+  },
+  approved: {
+    label: "Approved",
+    icon: "✓",
+    solidBg: "bg-green-100",
+    solidText: "text-green-700",
+  },
+  rejected: {
+    label: "Rejected",
+    icon: "✕",
+    solidBg: "bg-red-100",
+    solidText: "text-red-700",
+  },
+};
+
+function SectionVerifyControls({
+  verification,
+  loading,
+  onVerify,
+  onBulkApprove,
+  totalSections,
+  verificationMap,
+  sectionEntries,
+}: {
+  verification: SectionVerification | null;
+  loading: boolean;
+  onVerify: (status: SectionVerificationStatus) => void;
+  onBulkApprove?: () => void;
+  totalSections: number;
+  verificationMap: Map<string, SectionVerification>;
+  sectionEntries: SectionPickerEntry[];
+}) {
+  const currentStatus = verification?.status ?? "pending";
+  const cfg = VERIFY_STATUS_CONFIG[currentStatus];
+
+  // Count approved / total for progress
+  const approvedCount = sectionEntries.filter(
+    (e) =>
+      e.sectionResultId &&
+      verificationMap.get(e.sectionResultId)?.status === "approved",
+  ).length;
+  const allApproved = approvedCount === totalSections && totalSections > 0;
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* ── Status badge (non-interactive, solid pill) ── */}
+      <span
+        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold select-none ${cfg.solidBg} ${cfg.solidText}`}
+      >
+        <span className="text-[9px] leading-none">{cfg.icon}</span>
+        {cfg.label}
+      </span>
+
+      {/* Progress: 3/28 approved */}
+      <span className="text-[10px] text-gray-400 tabular-nums whitespace-nowrap">
+        {approvedCount}/{totalSections} approved
+      </span>
+
+      {/* ── Actions (visually grouped, text-style links) ── */}
+      <span className="w-px h-4 bg-gray-200" />
+      <div className="flex items-center gap-0.5">
+        {currentStatus !== "approved" && (
+          <button
+            type="button"
+            disabled={loading}
+            onClick={() => onVerify("approved")}
+            className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-green-700 hover:bg-green-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+            title="Approve this section"
+          >
+            Approve
+          </button>
+        )}
+        {currentStatus !== "rejected" && (
+          <button
+            type="button"
+            disabled={loading}
+            onClick={() => onVerify("rejected")}
+            className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+            title="Reject this section"
+          >
+            Reject
+          </button>
+        )}
+        {currentStatus !== "pending" && (
+          <button
+            type="button"
+            disabled={loading}
+            onClick={() => onVerify("pending")}
+            className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+            title="Reset to pending"
+          >
+            Reset
+          </button>
+        )}
+        {onBulkApprove && !allApproved && totalSections > 1 && (
+          <>
+            <span className="w-px h-3.5 bg-gray-200 mx-0.5" />
+            <button
+              type="button"
+              disabled={loading}
+              onClick={onBulkApprove}
+              className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-green-700 hover:bg-green-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+              title={`Approve all ${totalSections} sections`}
+            >
+              Approve all
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 type TabType = "results" | "markdown" | "compare" | "comments";
 type MarkdownViewType = "full" | "pages" | "chunks";
 
@@ -181,6 +347,9 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
   resultEnvelope,
   sectionResults,
   detectedSections,
+  sectionVerifications,
+  onSectionVerify,
+  onBulkSectionVerify,
 }) => {
   const { message } = App.useApp();
   const [activeTab, setActiveTab] = useState<TabType>("results");
@@ -196,19 +365,85 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
   // (a) the data shape matches and (b) there's at least one section to pick.
   // When v1 (or empty), we behave exactly as before.
   const isV2 = useMemo(
-    () => isV2ResultEnvelope(data, { result_envelope: resultEnvelope, section_results: sectionResults }),
-    [data, resultEnvelope, sectionResults]
+    () =>
+      isV2ResultEnvelope(data, {
+        result_envelope: resultEnvelope,
+        section_results: sectionResults,
+      }),
+    [data, resultEnvelope, sectionResults],
   );
   const sectionEntries = useMemo<SectionPickerEntry[]>(
-    () => (isV2 ? buildSectionPickerEntries(data as V2ResultEnvelope, sectionResults, detectedSections) : []),
-    [isV2, data, sectionResults, detectedSections]
+    () =>
+      isV2
+        ? buildSectionPickerEntries(
+            data as V2ResultEnvelope,
+            sectionResults,
+            detectedSections,
+          )
+        : [],
+    [isV2, data, sectionResults, detectedSections],
   );
-  const selectedSection = sectionEntries[selectedSectionIdx] ?? sectionEntries[0];
+  const selectedSection =
+    sectionEntries[selectedSectionIdx] ?? sectionEntries[0];
+
+  // Build a lookup map: section_result_id → verification row
+  const verificationMap = useMemo(() => {
+    const m = new Map<string, SectionVerification>();
+    if (sectionVerifications) {
+      for (const sv of sectionVerifications) {
+        m.set(sv.section_result_id, sv);
+      }
+    }
+    return m;
+  }, [sectionVerifications]);
+
+  const selectedVerification = selectedSection?.sectionResultId
+    ? (verificationMap.get(selectedSection.sectionResultId) ?? null)
+    : null;
+
+  const [verifyLoading, setVerifyLoading] = useState(false);
+
+  const handleVerify = useCallback(
+    async (status: SectionVerificationStatus) => {
+      if (!selectedSection?.sectionResultId || !onSectionVerify) return;
+      setVerifyLoading(true);
+      try {
+        await onSectionVerify(selectedSection.sectionResultId, status);
+        message.success(`Section marked as ${status}`);
+      } catch {
+        message.error("Failed to update verification");
+      } finally {
+        setVerifyLoading(false);
+      }
+    },
+    [selectedSection?.sectionResultId, onSectionVerify, message],
+  );
+
+  const handleBulkVerify = useCallback(
+    async (status: SectionVerificationStatus) => {
+      if (!onBulkSectionVerify) return;
+      const ids = sectionEntries
+        .map((e) => e.sectionResultId)
+        .filter((id): id is string => !!id);
+      if (ids.length === 0) return;
+      setVerifyLoading(true);
+      try {
+        await onBulkSectionVerify(ids, status);
+        message.success(`All ${ids.length} sections marked as ${status}`);
+      } catch {
+        message.error("Failed to bulk update");
+      } finally {
+        setVerifyLoading(false);
+      }
+    },
+    [sectionEntries, onBulkSectionVerify, message],
+  );
 
   // The data that the data-shaped tabs (Preview, JSON, CSV, Edit) operate on.
   // When v2 we scope to the selected section so the user sees one focused
   // result tree; when v1, we pass the original `data` through unchanged.
-  const sectionData: unknown = isV2 && selectedSection ? selectedSection.data : data;
+  const sectionData: unknown =
+    isV2 && selectedSection ? selectedSection.data : data;
 
   // Reset section selection when the underlying data shape changes (e.g.,
   // file switch). Otherwise an out-of-range index can persist briefly.
@@ -280,22 +515,12 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
 
         setJsonError(null);
       } catch (error) {
-        setJsonError(
-          error instanceof Error ? error.message : "Failed to save",
-        );
+        setJsonError(error instanceof Error ? error.message : "Failed to save");
       } finally {
         setIsSaving(false);
       }
     },
-    [
-      onUpdate,
-      jsonError,
-      isSaving,
-      editableJson,
-      isV2,
-      selectedSection,
-      data,
-    ],
+    [onUpdate, jsonError, isSaving, editableJson, isV2, selectedSection, data],
   );
 
   useEffect(() => {
@@ -360,9 +585,10 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    const sectionSuffix = isV2 && selectedSection
-      ? `_${selectedSection.slug}_${selectedSection.instanceIndex + 1}`
-      : "";
+    const sectionSuffix =
+      isV2 && selectedSection
+        ? `_${selectedSection.slug}_${selectedSection.instanceIndex + 1}`
+        : "";
     a.download = `${filename.replace(/\.[^/.]+$/, "")}${sectionSuffix}_results.csv`;
     document.body.appendChild(a);
     a.click();
@@ -401,7 +627,9 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
           <button
             type="button"
             disabled={selectedSectionIdx <= 0}
-            onClick={() => setSelectedSectionIdx(Math.max(0, selectedSectionIdx - 1))}
+            onClick={() =>
+              setSelectedSectionIdx(Math.max(0, selectedSectionIdx - 1))
+            }
             className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Previous section"
           >
@@ -420,7 +648,11 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
               const slugs = new Set(sectionEntries.map((e) => e.slug));
               if (slugs.size <= 1) {
                 return sectionEntries.map((entry) => (
-                  <Select.Option key={entry.globalIndex} value={entry.globalIndex} label={formatSectionOptionLabel(entry)}>
+                  <Select.Option
+                    key={entry.globalIndex}
+                    value={entry.globalIndex}
+                    label={formatSectionOptionLabel(entry)}
+                  >
                     {formatSectionOptionLabel(entry)}
                   </Select.Option>
                 ));
@@ -435,7 +667,11 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
                   {sectionEntries
                     .filter((e) => e.slug === slug)
                     .map((entry) => (
-                      <Select.Option key={entry.globalIndex} value={entry.globalIndex} label={`${entry.recordId ?? ''} ${formatSectionOptionLabel(entry)}`}>
+                      <Select.Option
+                        key={entry.globalIndex}
+                        value={entry.globalIndex}
+                        label={`${entry.recordId ?? ""} ${formatSectionOptionLabel(entry)}`}
+                      >
                         {formatSectionOptionLabel(entry)}
                       </Select.Option>
                     ))}
@@ -446,7 +682,11 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
           <button
             type="button"
             disabled={selectedSectionIdx >= sectionEntries.length - 1}
-            onClick={() => setSelectedSectionIdx(Math.min(sectionEntries.length - 1, selectedSectionIdx + 1))}
+            onClick={() =>
+              setSelectedSectionIdx(
+                Math.min(sectionEntries.length - 1, selectedSectionIdx + 1),
+              )
+            }
             className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Next section"
           >
@@ -455,6 +695,26 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
           <span className="text-xs text-gray-400 whitespace-nowrap tabular-nums">
             {selectedSectionIdx + 1} / {sectionEntries.length}
           </span>
+
+          {/* Verification controls */}
+          {onSectionVerify && selectedSection?.sectionResultId && (
+            <>
+              <span className="w-px h-5 bg-gray-200 mx-1" />
+              <SectionVerifyControls
+                verification={selectedVerification}
+                loading={verifyLoading}
+                onVerify={handleVerify}
+                onBulkApprove={
+                  onBulkSectionVerify
+                    ? () => handleBulkVerify("approved")
+                    : undefined
+                }
+                totalSections={sectionEntries.length}
+                verificationMap={verificationMap}
+                sectionEntries={sectionEntries}
+              />
+            </>
+          )}
         </div>
       )}
 
@@ -544,7 +804,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
                 text={editableJson}
                 onChange={({ text, isValid, error }) => {
                   setEditableJson(text);
-                  setJsonError(isValid ? null : error ?? "Invalid JSON");
+                  setJsonError(isValid ? null : (error ?? "Invalid JSON"));
                 }}
                 readOnly={!editable}
                 bordered={false}
@@ -1010,7 +1270,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
                                     </ReactMarkdown>
                                   </div>
                                 );
-                              }
+                              },
                             )}
                           </div>
                         </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -196,6 +196,7 @@ export interface JobFile {
         text: string;
         createdAt: string;
     }>;
+    section_verifications?: SectionVerification[];
 }
 
 export interface ProcessingConfig {
@@ -346,6 +347,7 @@ export type SectionResultStatus =
     | 'skipped_no_pages';
 
 export interface SectionResult {
+    section_result_id?: string;
     section_index: number;
     slug: string;
     record_id?: string | null;
@@ -355,6 +357,22 @@ export interface SectionResult {
     error?: string;
     duration_ms?: number;
     ai_metadata?: Record<string, unknown>;
+}
+
+// ── Section-level verification ──
+export type SectionVerificationStatus = 'pending' | 'approved' | 'rejected' | 'in_review';
+
+export interface SectionVerification {
+    id: string;
+    file_id: string;
+    section_result_id: string;
+    status: SectionVerificationStatus;
+    verified_by: string | null;
+    verified_by_email: string | null;
+    verified_at: string | null;
+    notes: string | null;
+    created_at: string;
+    updated_at: string;
 }
 
 /**
@@ -1443,6 +1461,36 @@ class ApiClient {
         return this.request(`/files/${fileId}/verify`, {
             method: 'PUT',
             body: JSON.stringify({ adminVerified, customerVerified }),
+        });
+    }
+
+    // ── Section-level verification ──
+
+    async getSectionVerifications(fileId: string): Promise<ApiResponse<SectionVerification[]>> {
+        return this.request(`/files/${fileId}/section-verifications`);
+    }
+
+    async updateSectionVerification(
+        fileId: string,
+        sectionResultId: string,
+        status: SectionVerificationStatus,
+        notes?: string,
+    ): Promise<ApiResponse<SectionVerification & { file_review_status: string }>> {
+        return this.request(`/files/${fileId}/section-verifications/${sectionResultId}`, {
+            method: 'PUT',
+            body: JSON.stringify({ status, notes }),
+        });
+    }
+
+    async bulkUpdateSectionVerifications(
+        fileId: string,
+        sectionResultIds: string[],
+        status: SectionVerificationStatus,
+        notes?: string,
+    ): Promise<ApiResponse<SectionVerification[]>> {
+        return this.request(`/files/${fileId}/section-verifications-bulk`, {
+            method: 'PUT',
+            body: JSON.stringify({ sectionResultIds, status, notes }),
         });
     }
 


### PR DESCRIPTION
## Summary
- **Verification controls** in section picker: status badge (solid pill with icon), approve/reject/reset actions, bulk approve-all, progress counter
- **Clear status vs actions separation**: status is a non-interactive pill, actions are muted text links that highlight on hover
- **API client**: `SectionVerification` types, `getSectionVerifications()`, `updateSectionVerification()`, `bulkUpdateSectionVerifications()` methods
- **`section_result_id`** read from result data (where backfill placed it), with fallback to `section_results` metadata
- **State management** in `FileViewerRightPane`: optimistic updates, re-sync on file switch

## Test plan
- [x] Open a v2 file — verification controls visible next to section counter
- [x] Approve a section — badge changes to green "✓ Approved", progress updates
- [x] Reject a section — badge changes to red "✕ Rejected"  
- [x] Reset — badge returns to gray "○ Pending"
- [x] "Approve all" — all sections approved, button disappears
- [x] Switch between files — verification state loads correctly for each

🤖 Generated with [Claude Code](https://claude.com/claude-code)