### PR TITLE
feat: client-side split/merge with draft-save workflow

### DIFF
--- a/src/components/DocumentRoutingPanel.tsx
+++ b/src/components/DocumentRoutingPanel.tsx
@@ -28,6 +28,13 @@ import {
   DetectedSections,
   DocumentTypeInfo,
 } from "@/lib/api";
+import {
+  splitSection,
+  mergeSections,
+  changeSectionSlug,
+  hasUnsavedChanges,
+  getSectionsNeedingExtraction,
+} from "@/lib/routingEdits";
 
 interface Props {
   fileId: string;
@@ -245,16 +252,28 @@ export default function DocumentRoutingPanel({
   onSectionsUpdated,
 }: Props) {
   const { message } = App.useApp();
-  const sections = detectedSections?.sections ?? [];
-  const pages = detectedSections?.pages ?? [];
 
-  // Slugs for the change-slug picker. Loaded once; cheap. Empty array until
-  // the request completes — the picker shows a "loading" state.
+  // ── Local draft state ─────────────────────────────────────────────
+  // Split/merge/slug-change are performed client-side on a local copy.
+  // Nothing hits the server until the user clicks "Save & Re-extract".
+  // "Discard" resets to the server version.
+  const [draft, setDraft] = useState<DetectedSections | null>(null);
+
+  // Reset draft when the server state changes (file switch, post-save refresh)
+  useEffect(() => {
+    setDraft(null);
+  }, [detectedSections]);
+
+  // The "active" blob: draft if editing, otherwise server state
+  const activeSections = draft ?? detectedSections;
+  const sections = activeSections?.sections ?? [];
+  const pages = activeSections?.pages ?? [];
+  const isDirty = draft !== null;
+
+  // Slugs for the change-slug picker
   const [availableSlugs, setAvailableSlugs] = useState<DocumentTypeInfo[]>([]);
   const [slugsLoaded, setSlugsLoaded] = useState(false);
 
-  // Single in-flight action at a time. Index is into `sections`; kind drives
-  // which modal opens. `null` when no modal is open.
   const [activeAction, setActiveAction] = useState<ActionState | null>(null);
   const [actionLoadingFor, setActionLoadingFor] = useState<number | null>(null);
   const [pickedSlug, setPickedSlug] = useState<string | null>(null);
@@ -286,14 +305,18 @@ export default function DocumentRoutingPanel({
     setPickedSplitPage(null);
   }, []);
 
+  // ── Client-side edit handlers (no server calls) ───────────────────
+
   const handleApprove = useCallback(
     async (sectionIndex: number) => {
+      // Approve still goes to the server (it's a lightweight status flip,
+      // not a structural change that needs undo support).
       setActionLoadingFor(sectionIndex);
       try {
         const res = await apiClient.routingApproveSection(fileId, sectionIndex);
-        if (res.success && res.data?.detected_sections) {
+        if (res.success && res.detected_sections) {
           message.success("Section approved");
-          onSectionsUpdated?.(res.data.detected_sections);
+          onSectionsUpdated?.(res.detected_sections);
         } else {
           message.error(res.message || "Approve failed");
         }
@@ -306,113 +329,90 @@ export default function DocumentRoutingPanel({
     [fileId, onSectionsUpdated],
   );
 
-  const handleChangeSlug = useCallback(async () => {
+  const handleChangeSlug = useCallback(() => {
     if (!activeAction || activeAction.kind !== "change_slug" || !pickedSlug) return;
-    setActionLoadingFor(activeAction.sectionIndex);
+    if (!activeSections) return;
     try {
-      const res = await apiClient.routingChangeSectionSlug(
-        fileId,
-        activeAction.sectionIndex,
-        pickedSlug,
-      );
-      if (res.success && res.data?.detected_sections) {
-        message.success(`Section re-routed to ${pickedSlug}`);
-        onSectionsUpdated?.(res.data.detected_sections);
-        closeAction();
-      } else {
-        message.error(res.message || "Change failed");
-      }
+      const updated = changeSectionSlug(activeSections, activeAction.sectionIndex, pickedSlug);
+      setDraft(updated);
+      message.success(`Section re-routed to ${pickedSlug} (unsaved)`);
+      closeAction();
     } catch (err: unknown) {
       message.error(err instanceof Error ? err.message : "Change failed");
-    } finally {
-      setActionLoadingFor(null);
     }
-  }, [activeAction, pickedSlug, fileId, onSectionsUpdated, closeAction]);
+  }, [activeAction, pickedSlug, activeSections, closeAction]);
 
-  const handleSplit = useCallback(async () => {
+  const handleSplit = useCallback(() => {
     if (!activeAction || activeAction.kind !== "split" || pickedSplitPage == null) return;
-    setActionLoadingFor(activeAction.sectionIndex);
+    if (!activeSections) return;
     try {
-      const res = await apiClient.routingSplitSection(
-        fileId,
-        activeAction.sectionIndex,
-        pickedSplitPage,
-      );
-      if (res.success && res.data?.detected_sections) {
-        message.success(`Section split at page ${pickedSplitPage}`);
-        onSectionsUpdated?.(res.data.detected_sections);
-        closeAction();
-      } else {
-        message.error(res.message || "Split failed");
-      }
+      const updated = splitSection(activeSections, activeAction.sectionIndex, pickedSplitPage);
+      setDraft(updated);
+      message.success(`Section split at page ${pickedSplitPage} (unsaved)`);
+      closeAction();
     } catch (err: unknown) {
       message.error(err instanceof Error ? err.message : "Split failed");
-    } finally {
-      setActionLoadingFor(null);
     }
-  }, [activeAction, pickedSplitPage, fileId, onSectionsUpdated, closeAction]);
+  }, [activeAction, pickedSplitPage, activeSections, closeAction]);
 
   const handleMerge = useCallback(
-    async (sectionIndex: number) => {
-      setActionLoadingFor(sectionIndex);
+    (sectionIndex: number) => {
+      if (!activeSections) return;
       try {
-        const res = await apiClient.routingMergeSections(
-          fileId,
-          sectionIndex,
-          sectionIndex + 1,
-        );
-        if (res.success && res.data?.detected_sections) {
-          message.success("Sections merged");
-          onSectionsUpdated?.(res.data.detected_sections);
-        } else {
-          message.error(res.message || "Merge failed");
-        }
+        const updated = mergeSections(activeSections, sectionIndex);
+        setDraft(updated);
+        message.success("Sections merged (unsaved)");
       } catch (err: unknown) {
         message.error(err instanceof Error ? err.message : "Merge failed");
-      } finally {
-        setActionLoadingFor(null);
       }
     },
-    [fileId, onSectionsUpdated],
+    [activeSections],
   );
 
-  const [reextractLoading, setReextractLoading] = useState(false);
+  const handleDiscard = useCallback(() => {
+    setDraft(null);
+    message.info("Changes discarded");
+  }, []);
 
-  const handleReextract = useCallback(
-    async (sectionIndices: number[]) => {
-      setReextractLoading(true);
-      try {
-        const res = await apiClient.reextractSections(fileId, sectionIndices);
-        if (res.status === "success") {
-          message.success(
-            `Re-extracted ${sectionIndices.length} section${sectionIndices.length === 1 ? "" : "s"}`,
-          );
-          // The response includes updated detected_sections (with new section_result_ids
-          // and cleared edits). Push it to the parent so the UI refreshes.
-          if (res.data?.detected_sections) {
-            onSectionsUpdated?.(res.data.detected_sections);
-          }
-        } else {
-          message.error(res.message || "Re-extraction failed");
+  // ── Save & Re-extract (the only server call for edits) ────────────
+
+  const [saveLoading, setSaveLoading] = useState(false);
+
+  const handleSaveAndReextract = useCallback(async () => {
+    if (!draft) return;
+    setSaveLoading(true);
+    try {
+      const res = await apiClient.saveAndReextractSections(fileId, draft);
+      if (res.status === "success") {
+        const count = getSectionsNeedingExtraction(draft).length;
+        message.success(
+          count > 0
+            ? `Saved and re-extracted ${count} section${count === 1 ? "" : "s"}`
+            : "Saved (no extraction needed)",
+        );
+        if (res.detected_sections) {
+          onSectionsUpdated?.(res.detected_sections);
         }
-      } catch (err: unknown) {
-        message.error(err instanceof Error ? err.message : "Re-extraction failed");
-      } finally {
-        setReextractLoading(false);
+        setDraft(null);
+      } else {
+        message.error(res.message || "Save failed");
       }
-    },
-    [fileId, onSectionsUpdated],
-  );
+    } catch (err: unknown) {
+      message.error(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaveLoading(false);
+    }
+  }, [draft, fileId, onSectionsUpdated]);
 
-  // Sections that need extraction: section_result_id is null (set by split/merge/slug-change).
-  // No edit-tracking needed — the null ID is the single source of truth.
+  // Sections needing extraction (for the old re-extract banner on server state)
   const needsExtractionIndices = useMemo(() => {
-    return sections
-      .map((s, i) => (s.section_result_id == null ? i : -1))
-      .filter((i) => i >= 0);
-  }, [sections]);
+    return getSectionsNeedingExtraction(detectedSections);
+  }, [detectedSections]);
 
-  const hasEdits = needsExtractionIndices.length > 0;
+  // Draft sections needing extraction
+  const draftNeedsExtraction = useMemo(() => {
+    return draft ? getSectionsNeedingExtraction(draft) : [];
+  }, [draft]);
 
   // High-level summary numbers.
   const summary = useMemo(() => {
@@ -540,38 +540,70 @@ export default function DocumentRoutingPanel({
         </div>
       )}
 
-      {/* Re-extract banner — shown when sections need extraction */}
-      {hasEdits && sections.length > 0 && (
-        <div className="mx-2 mb-2 p-2.5 rounded-md bg-amber-50 border border-amber-200 flex flex-col gap-2">
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-xs text-amber-800">
-              {needsExtractionIndices.length === sections.length
-                ? "All sections need extraction."
-                : `${needsExtractionIndices.length} section${needsExtractionIndices.length === 1 ? "" : "s"} need${needsExtractionIndices.length === 1 ? "s" : ""} extraction (${needsExtractionIndices.map((i) => {
-                    const s = sections[i];
-                    return s ? `p${s.page_range[0]}${s.page_range[1] !== s.page_range[0] ? `-${s.page_range[1]}` : ""}` : `#${i}`;
-                  }).join(", ")}).`}
-            </span>
-          </div>
+      {/* Draft banner — unsaved local edits */}
+      {isDirty && sections.length > 0 && (
+        <div className="mx-2 mb-2 p-2.5 rounded-md bg-blue-50 border border-blue-200 flex flex-col gap-2">
+          <span className="text-xs text-blue-800">
+            {draftNeedsExtraction.length > 0
+              ? `${draftNeedsExtraction.length} section${draftNeedsExtraction.length === 1 ? "" : "s"} changed (${draftNeedsExtraction.map((i) => {
+                  const s = sections[i];
+                  return s ? `p${s.page_range[0]}${s.page_range[1] !== s.page_range[0] ? `-${s.page_range[1]}` : ""}` : `#${i}`;
+                }).join(", ")}). Save to persist and re-extract.`
+              : "Sections modified. Save to persist changes."}
+          </span>
           <div className="flex items-center gap-2">
             <Button
               size="small"
               type="primary"
-              loading={reextractLoading}
-              onClick={() => handleReextract(needsExtractionIndices)}
+              loading={saveLoading}
+              onClick={handleSaveAndReextract}
             >
-              Re-extract ({needsExtractionIndices.length})
+              Save & Re-extract ({draftNeedsExtraction.length})
             </Button>
-            {needsExtractionIndices.length < sections.length && (
-              <Button
-                size="small"
-                loading={reextractLoading}
-                onClick={() => handleReextract(sections.map((_, i) => i))}
-              >
-                Re-extract all
-              </Button>
-            )}
+            <Button
+              size="small"
+              onClick={handleDiscard}
+              disabled={saveLoading}
+            >
+              Discard
+            </Button>
           </div>
+        </div>
+      )}
+
+      {/* Server-side needs-extraction banner (for files that already have null IDs from prior edits) */}
+      {!isDirty && needsExtractionIndices.length > 0 && sections.length > 0 && (
+        <div className="mx-2 mb-2 p-2.5 rounded-md bg-amber-50 border border-amber-200 flex flex-col gap-2">
+          <span className="text-xs text-amber-800">
+            {needsExtractionIndices.length} section{needsExtractionIndices.length === 1 ? "" : "s"} need{needsExtractionIndices.length === 1 ? "s" : ""} extraction.
+          </span>
+          <Button
+            size="small"
+            type="primary"
+            loading={saveLoading}
+            onClick={() => {
+              // Save existing detected_sections (with null IDs) to trigger re-extract
+              if (detectedSections) {
+                setDraft(detectedSections);
+                // Immediately save — the user didn't make local edits, they just need re-extract
+                apiClient.saveAndReextractSections(fileId, detectedSections).then((res) => {
+                  if (res.status === "success" && res.detected_sections) {
+                    message.success(`Re-extracted ${needsExtractionIndices.length} section(s)`);
+                    onSectionsUpdated?.(res.detected_sections);
+                    setDraft(null);
+                  } else {
+                    message.error(res.message || "Re-extraction failed");
+                    setDraft(null);
+                  }
+                }).catch((err) => {
+                  message.error(err instanceof Error ? err.message : "Re-extraction failed");
+                  setDraft(null);
+                });
+              }
+            }}
+          >
+            Re-extract ({needsExtractionIndices.length})
+          </Button>
         </div>
       )}
 
@@ -807,21 +839,13 @@ function SectionActions({
             : "No next section to merge with"
         }
       >
-        <Popconfirm
-          title="Merge with next section?"
-          description="The two sections will be combined into one. You can split them again later."
-          okText="Merge"
-          cancelText="Cancel"
-          onConfirm={onMerge}
+        <Button
+          size="small"
+          onClick={onMerge}
           disabled={!canMerge || loading}
         >
-          <Button
-            size="small"
-            disabled={!canMerge || loading}
-          >
-            Merge
-          </Button>
-        </Popconfirm>
+          Merge
+        </Button>
       </Tooltip>
     </Space>
   );
@@ -829,6 +853,7 @@ function SectionActions({
 
 function SectionHeader({ section }: { section: DetectedSection }) {
   const [start, end] = section.page_range;
+  const needsExtraction = section.section_result_id == null;
   return (
     <div className="flex items-center gap-2 flex-wrap">
       <span className="font-mono text-sm font-medium">
@@ -837,6 +862,11 @@ function SectionHeader({ section }: { section: DetectedSection }) {
       <span className="text-sm text-gray-500">
         pages {start}–{end} ({section.page_count})
       </span>
+      {needsExtraction && (
+        <Tag color="warning" style={{ marginInlineEnd: 0 }}>
+          needs extraction
+        </Tag>
+      )}
       <Tag
         color={statusColor(section.status)}
         style={{ marginInlineEnd: 0 }}

--- a/src/components/DocumentRoutingPanel.tsx
+++ b/src/components/DocumentRoutingPanel.tsx
@@ -52,7 +52,7 @@ interface Props {
   onSectionsUpdated?: (next: DetectedSections) => void;
 }
 
-type ActionKind = "change_slug" | "split";
+type ActionKind = "change_slug" | "split" | "merge";
 interface ActionState {
   kind: ActionKind;
   sectionIndex: number;
@@ -352,6 +352,68 @@ export default function DocumentRoutingPanel({
     }
   }, [activeAction, pickedSplitPage, fileId, onSectionsUpdated, closeAction]);
 
+  const handleMerge = useCallback(
+    async (sectionIndex: number) => {
+      setActionLoadingFor(sectionIndex);
+      try {
+        const res = await apiClient.routingMergeSections(
+          fileId,
+          sectionIndex,
+          sectionIndex + 1,
+        );
+        if (res.success && res.data?.detected_sections) {
+          message.success("Sections merged");
+          onSectionsUpdated?.(res.data.detected_sections);
+        } else {
+          message.error(res.message || "Merge failed");
+        }
+      } catch (err: unknown) {
+        message.error(err instanceof Error ? err.message : "Merge failed");
+      } finally {
+        setActionLoadingFor(null);
+      }
+    },
+    [fileId, onSectionsUpdated],
+  );
+
+  const [reextractLoading, setReextractLoading] = useState(false);
+
+  const handleReextract = useCallback(
+    async (sectionIndices: number[]) => {
+      setReextractLoading(true);
+      try {
+        const res = await apiClient.reextractSections(fileId, sectionIndices);
+        if (res.status === "success") {
+          message.success(
+            `Re-extracted ${sectionIndices.length} section${sectionIndices.length === 1 ? "" : "s"}`,
+          );
+          // The response includes updated detected_sections (with new section_result_ids
+          // and cleared edits). Push it to the parent so the UI refreshes.
+          if (res.data?.detected_sections) {
+            onSectionsUpdated?.(res.data.detected_sections);
+          }
+        } else {
+          message.error(res.message || "Re-extraction failed");
+        }
+      } catch (err: unknown) {
+        message.error(err instanceof Error ? err.message : "Re-extraction failed");
+      } finally {
+        setReextractLoading(false);
+      }
+    },
+    [fileId, onSectionsUpdated],
+  );
+
+  // Sections that need extraction: section_result_id is null (set by split/merge/slug-change).
+  // No edit-tracking needed — the null ID is the single source of truth.
+  const needsExtractionIndices = useMemo(() => {
+    return sections
+      .map((s, i) => (s.section_result_id == null ? i : -1))
+      .filter((i) => i >= 0);
+  }, [sections]);
+
+  const hasEdits = needsExtractionIndices.length > 0;
+
   // High-level summary numbers.
   const summary = useMemo(() => {
     const totalPages = pages.length;
@@ -478,6 +540,41 @@ export default function DocumentRoutingPanel({
         </div>
       )}
 
+      {/* Re-extract banner — shown when sections need extraction */}
+      {hasEdits && sections.length > 0 && (
+        <div className="mx-2 mb-2 p-2.5 rounded-md bg-amber-50 border border-amber-200 flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-amber-800">
+              {needsExtractionIndices.length === sections.length
+                ? "All sections need extraction."
+                : `${needsExtractionIndices.length} section${needsExtractionIndices.length === 1 ? "" : "s"} need${needsExtractionIndices.length === 1 ? "s" : ""} extraction (${needsExtractionIndices.map((i) => {
+                    const s = sections[i];
+                    return s ? `p${s.page_range[0]}${s.page_range[1] !== s.page_range[0] ? `-${s.page_range[1]}` : ""}` : `#${i}`;
+                  }).join(", ")}).`}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="small"
+              type="primary"
+              loading={reextractLoading}
+              onClick={() => handleReextract(needsExtractionIndices)}
+            >
+              Re-extract ({needsExtractionIndices.length})
+            </Button>
+            {needsExtractionIndices.length < sections.length && (
+              <Button
+                size="small"
+                loading={reextractLoading}
+                onClick={() => handleReextract(sections.map((_, i) => i))}
+              >
+                Re-extract all
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Sections */}
       {sections.length === 0 ? (
         <div className="text-sm text-gray-500 italic px-2">
@@ -497,6 +594,7 @@ export default function DocumentRoutingPanel({
                 <SectionActions
                   section={section}
                   loading={actionLoadingFor === i}
+                  isLastSection={i === sections.length - 1}
                   onApprove={() => handleApprove(i)}
                   onChangeSlug={() => {
                     setPickedSlug(section.document_type_slug);
@@ -506,6 +604,7 @@ export default function DocumentRoutingPanel({
                     setPickedSplitPage(null);
                     setActiveAction({ kind: "split", sectionIndex: i });
                   }}
+                  onMerge={() => handleMerge(i)}
                 />
               ),
               children: (
@@ -650,18 +749,23 @@ export default function DocumentRoutingPanel({
 function SectionActions({
   section,
   loading,
+  isLastSection,
   onApprove,
   onChangeSlug,
   onSplit,
+  onMerge,
 }: {
   section: DetectedSection;
   loading: boolean;
+  isLastSection: boolean;
   onApprove: () => void;
   onChangeSlug: () => void;
   onSplit: () => void;
+  onMerge: () => void;
 }) {
   const [start, end] = section.page_range;
   const canSplit = end > start;
+  const canMerge = !isLastSection; // can merge with next section (unless this is the last one)
   const isPending = section.status === "pending_review";
 
   // stopPropagation so clicks don't toggle the Collapse panel.
@@ -695,6 +799,29 @@ function SectionActions({
         >
           Split
         </Button>
+      </Tooltip>
+      <Tooltip
+        title={
+          canMerge
+            ? "Merge this section with the next one"
+            : "No next section to merge with"
+        }
+      >
+        <Popconfirm
+          title="Merge with next section?"
+          description="The two sections will be combined into one. You can split them again later."
+          okText="Merge"
+          cancelText="Cancel"
+          onConfirm={onMerge}
+          disabled={!canMerge || loading}
+        >
+          <Button
+            size="small"
+            disabled={!canMerge || loading}
+          >
+            Merge
+          </Button>
+        </Popconfirm>
       </Tooltip>
     </Space>
   );

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -10,6 +10,7 @@ import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
 import { App, Button, Input, Select, Typography } from "antd";
 import { JsonViewer } from "@/components/json";
 import {
+  apiClient,
   isV2ResultEnvelope,
   type SectionResult,
   type SectionVerification,
@@ -483,8 +484,9 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
   };
 
   // Save changes. For v2 we splice the edited section back into the envelope
-  // and call onUpdate with the full envelope so the file's persisted result
-  // shape stays consistent (downstream consumers always see V2ResultEnvelope).
+  // Save the current section's edited JSON.
+  // V2 with section_result_id: use the PATCH endpoint (small payload, no size limit issues).
+  // V1 or V2 without section_result_id: fall back to the full-result PUT via onUpdate.
   const handleSave = useCallback(
     async (e?: React.MouseEvent) => {
       if (e) {
@@ -498,7 +500,24 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
         setIsSaving(true);
         const parsedSectionData = JSON.parse(editableJson);
 
-        if (isV2 && selectedSection) {
+        if (isV2 && selectedSection?.sectionResultId && fileId) {
+          // V2 path: patch just this one record by section_result_id.
+          // Strip section_result_id from the edited data (the endpoint preserves it).
+          const { section_result_id: _strip, ...recordData } = parsedSectionData;
+          const res = await apiClient.patchResultRecord(
+            fileId,
+            selectedSection.sectionResultId,
+            recordData,
+          );
+          if (!res.success) {
+            throw new Error(res.message || "Failed to save");
+          }
+          // Don't call onUpdate here — the PATCH already saved to the server
+          // and emitted a WebSocket event (emitFileFullPatch) that will refresh
+          // the parent's file data. Calling onUpdate would trigger the old PUT
+          // endpoint with the full envelope, causing PayloadTooLargeError.
+        } else if (isV2 && selectedSection) {
+          // V2 but no section_result_id (legacy file) — full envelope PUT
           const envelope = data as V2ResultEnvelope;
           const slugInstances = Array.isArray(envelope[selectedSection.slug])
             ? [...envelope[selectedSection.slug]]
@@ -510,6 +529,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
           };
           await onUpdate(nextEnvelope);
         } else {
+          // V1 — full result PUT
           await onUpdate(parsedSectionData);
         }
 
@@ -520,7 +540,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
         setIsSaving(false);
       }
     },
-    [onUpdate, jsonError, isSaving, editableJson, isV2, selectedSection, data],
+    [onUpdate, jsonError, isSaving, editableJson, isV2, selectedSection, data, fileId],
   );
 
   useEffect(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -989,6 +989,19 @@ class ApiClient {
         );
     }
 
+    async saveAndReextractSections(
+        fileId: string,
+        detectedSections: DetectedSections,
+    ): Promise<ApiResponse<{ detected_sections?: DetectedSections; sectionResults?: unknown[] }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/sections/save-and-reextract`,
+            {
+                method: 'POST',
+                body: JSON.stringify({ detected_sections: detectedSections }),
+            },
+        );
+    }
+
     async reextractSections(
         fileId: string,
         sectionIndices: number[],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1495,6 +1495,21 @@ class ApiClient {
         });
     }
 
+    /** Patch a single record in a V2 envelope by section_result_id. */
+    async patchResultRecord(
+        fileId: string,
+        sectionResultId: string,
+        data: Record<string, unknown>,
+    ): Promise<ApiResponse<{ fileId: string; filename: string; sectionResultId: string }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/result/${encodeURIComponent(sectionResultId)}`,
+            {
+                method: 'PATCH',
+                body: JSON.stringify({ data }),
+            },
+        );
+    }
+
     async updateFileResults(fileId: string, results: any): Promise<ApiResponse<{ fileId: string; filename: string; results: any; flags?: any[] }>> {
         return this.request(`/files/${fileId}/results`, {
             method: 'PUT',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -308,6 +308,9 @@ export interface DetectedSection {
     min_page_confidence: number;
     status: 'auto_approved' | 'pending_review' | 'approved' | string;
     threshold_used: number;
+    /** Stable link to the extraction record in the V2 envelope. Null when the
+     *  section needs (re-)extraction (set by split/merge/slug-change). */
+    section_result_id?: string | null;
 }
 
 export interface DetectedSections {
@@ -325,6 +328,7 @@ export interface DetectedSections {
     pages: DetectedPage[];
     sections: DetectedSection[];
     status: 'auto_approved' | 'pending_review' | 'skipped' | string;
+    edits?: Array<{ kind: string; ts: string; [k: string]: unknown }>;
 }
 
 // Per-section extraction (Phase 1, item #3 — v2 envelope).
@@ -966,6 +970,34 @@ class ApiClient {
             {
                 method: 'POST',
                 body: JSON.stringify({ atPage }),
+            },
+        );
+    }
+
+    async routingMergeSections(
+        fileId: string,
+        indexA: number,
+        indexB: number,
+        slug?: string,
+    ): Promise<ApiResponse<{ detected_sections: DetectedSections }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/sections/merge`,
+            {
+                method: 'POST',
+                body: JSON.stringify({ indexA, indexB, ...(slug ? { slug } : {}) }),
+            },
+        );
+    }
+
+    async reextractSections(
+        fileId: string,
+        sectionIndices: number[],
+    ): Promise<ApiResponse<{ sectionResults: unknown[]; detected_sections?: DetectedSections }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/reextract-sections`,
+            {
+                method: 'POST',
+                body: JSON.stringify({ sectionIndices }),
             },
         );
     }

--- a/src/lib/routingEdits.ts
+++ b/src/lib/routingEdits.ts
@@ -1,0 +1,230 @@
+/**
+ * Client-side routing edit functions (split, merge, slug change).
+ *
+ * These are pure functions that transform a DetectedSections blob without
+ * any server calls. The user can split/merge freely in the UI; changes
+ * are only persisted when they click "Save & Re-extract".
+ *
+ * Ported from ai/src/services/sectionRoutingEdits.js — same logic,
+ * same output shape.
+ */
+
+import type { DetectedSections, DetectedSection, DetectedPage } from "./api";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function cloneBlob(blob: DetectedSections): DetectedSections {
+  return JSON.parse(JSON.stringify(blob));
+}
+
+function requireSection(blob: DetectedSections, index: number): DetectedSection {
+  if (!Array.isArray(blob.sections)) {
+    throw new Error("detected_sections.sections is missing");
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= blob.sections.length) {
+    throw new Error(
+      `Section index ${index} is out of range (0..${blob.sections.length - 1})`
+    );
+  }
+  return blob.sections[index];
+}
+
+function deriveFileStatus(
+  sections: DetectedSection[]
+): string {
+  if (!Array.isArray(sections) || sections.length === 0) return "skipped";
+  if (sections.some((s) => s.status === "pending_review")) return "pending_review";
+  return "auto_approved";
+}
+
+const EXTRACTABLE_PURPOSE = "data";
+
+function buildSectionFromPages(
+  allPages: DetectedPage[],
+  [start, end]: [number, number],
+  proto: DetectedSection
+): DetectedSection {
+  const inRange = allPages.filter(
+    (p) =>
+      typeof p?.page_number === "number" &&
+      p.page_number >= start &&
+      p.page_number <= end
+  );
+
+  const extraction_pages: number[] = [];
+  const skipped_pages: DetectedSection["skipped_pages"] = [];
+  const page_roles: (string | null)[] = [];
+  const page_purposes: string[] = [];
+  const confidences: number[] = [];
+
+  for (const p of inRange) {
+    const purpose = p.page_purpose ?? "unknown";
+    const isData = purpose === EXTRACTABLE_PURPOSE;
+    const isDuplicate = p.duplicate_of != null;
+
+    if (isData && !isDuplicate) {
+      extraction_pages.push(p.page_number);
+    } else if (isDuplicate) {
+      skipped_pages.push({
+        page_number: p.page_number,
+        reason: "duplicate",
+      });
+    } else {
+      skipped_pages.push({ page_number: p.page_number, reason: purpose });
+    }
+
+    page_roles.push(p.page_role ?? null);
+    page_purposes.push(purpose);
+    confidences.push(typeof p.confidence === "number" ? p.confidence : 0);
+  }
+
+  const confidence = confidences.length
+    ? confidences.reduce((a, b) => a + b, 0) / confidences.length
+    : 0;
+  const minConfidence = confidences.length ? Math.min(...confidences) : 0;
+
+  return {
+    document_type_slug: proto.document_type_slug,
+    page_range: [start, end],
+    page_count: end - start + 1,
+    extraction_pages,
+    skipped_pages,
+    page_roles,
+    page_purposes,
+    confidence: Number(confidence.toFixed(4)),
+    min_page_confidence: Number(minConfidence.toFixed(4)),
+    status: "approved",
+    threshold_used: proto.threshold_used,
+    section_result_id: null,
+  };
+}
+
+// ─── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Split a section into two at `atPage`.
+ * First half: [section.start, atPage - 1], second: [atPage, section.end].
+ * Both halves get section_result_id: null (need extraction).
+ */
+export function splitSection(
+  detectedSections: DetectedSections,
+  index: number,
+  atPage: number
+): DetectedSections {
+  if (!Number.isInteger(atPage) || atPage < 1) {
+    throw new Error(`Invalid atPage '${atPage}' — must be a positive integer`);
+  }
+
+  const blob = cloneBlob(detectedSections);
+  const section = requireSection(blob, index);
+  const [start, end] = section.page_range;
+
+  if (atPage <= start || atPage > end) {
+    throw new Error(
+      `atPage ${atPage} is outside section range (${start}–${end})`
+    );
+  }
+
+  const allPages = blob.pages ?? [];
+  const first = buildSectionFromPages(allPages, [start, atPage - 1], section);
+  const second = buildSectionFromPages(allPages, [atPage, end], section);
+
+  blob.sections.splice(index, 1, first, second);
+  blob.status = deriveFileStatus(blob.sections);
+  return blob;
+}
+
+/**
+ * Merge two adjacent sections into one.
+ * The merged section inherits the first section's slug.
+ * Gets section_result_id: null (needs extraction).
+ */
+export function mergeSections(
+  detectedSections: DetectedSections,
+  indexA: number
+): DetectedSections {
+  const indexB = indexA + 1;
+
+  const blob = cloneBlob(detectedSections);
+  const secA = requireSection(blob, indexA);
+  const secB = requireSection(blob, indexB);
+
+  if (secA.page_range[1] + 1 !== secB.page_range[0]) {
+    throw new Error(
+      `Sections are not page-adjacent: section ${indexA} ends at page ${secA.page_range[1]}, ` +
+        `section ${indexB} starts at page ${secB.page_range[0]}`
+    );
+  }
+
+  const allPages = blob.pages ?? [];
+  const mergedRange: [number, number] = [secA.page_range[0], secB.page_range[1]];
+  const merged = buildSectionFromPages(allPages, mergedRange, secA);
+
+  blob.sections.splice(indexA, 2, merged);
+  blob.status = deriveFileStatus(blob.sections);
+  return blob;
+}
+
+/**
+ * Change a section's document type slug.
+ * Sets section_result_id: null (different schema → needs extraction).
+ */
+export function changeSectionSlug(
+  detectedSections: DetectedSections,
+  index: number,
+  slug: string
+): DetectedSections {
+  const blob = cloneBlob(detectedSections);
+  const section = requireSection(blob, index);
+
+  section.document_type_slug = slug;
+  section.status = "approved";
+  section.section_result_id = null;
+
+  // Update per-page slugs within the section's range
+  const [start, end] = section.page_range;
+  for (const p of blob.pages ?? []) {
+    if (
+      typeof p.page_number === "number" &&
+      p.page_number >= start &&
+      p.page_number <= end
+    ) {
+      p.document_type_slug = slug;
+    }
+  }
+
+  blob.status = deriveFileStatus(blob.sections);
+  return blob;
+}
+
+/**
+ * Check if a DetectedSections blob has unsaved changes compared to another.
+ * Compares section count, page ranges, slugs, and section_result_ids.
+ */
+export function hasUnsavedChanges(
+  current: DetectedSections | null | undefined,
+  saved: DetectedSections | null | undefined
+): boolean {
+  if (!current || !saved) return false;
+  if (current.sections.length !== saved.sections.length) return true;
+  for (let i = 0; i < current.sections.length; i++) {
+    const c = current.sections[i];
+    const s = saved.sections[i];
+    if (c.document_type_slug !== s.document_type_slug) return true;
+    if (c.page_range[0] !== s.page_range[0] || c.page_range[1] !== s.page_range[1]) return true;
+    if (c.section_result_id !== s.section_result_id) return true;
+  }
+  return false;
+}
+
+/**
+ * Get indices of sections that need extraction (section_result_id is null).
+ */
+export function getSectionsNeedingExtraction(
+  detectedSections: DetectedSections | null | undefined
+): number[] {
+  if (!detectedSections?.sections) return [];
+  return detectedSections.sections
+    .map((s, i) => (s.section_result_id == null ? i : -1))
+    .filter((i) => i >= 0);
+}


### PR DESCRIPTION
## Summary
- **Client-side routing edits**: Split/merge/slug-change are now instant local operations — no server calls until "Save & Re-extract"
- **Draft workflow**: Blue banner shows changed sections with "Save & Re-extract" and "Discard" buttons. Accidental edits cost nothing to undo.
- **routingEdits.ts**: Pure TypeScript port of backend split/merge/slug-change functions
- **"needs extraction" tag**: Sections with `null` section_result_id show an orange tag in the header
- **Merge button**: Added to every section row (merges with next section)

### Files changed
| File | Change |
|------|--------|
| `routingEdits.ts` | **NEW** — `splitSection()`, `mergeSections()`, `changeSectionSlug()`, `hasUnsavedChanges()`, `getSectionsNeedingExtraction()` |
| `DocumentRoutingPanel.tsx` | Local draft state, save/discard banner, merge button, needs-extraction tag |
| `api.ts` | Added `saveAndReextractSections()`, `section_result_id` on `DetectedSection` type |

## Test plan
- [x] Split → instant in UI, blue banner appears with "Save & Re-extract (N)" + "Discard"
- [x] Discard → reverts to server state, no API calls
- [x] Split + merge back + discard → zero cost round-trip
- [x] Save & Re-extract → server call, IDs written, banner clears
- [x] "needs extraction" orange tag on sections with null IDs
- [x] No false error popups (split/merge are client-side now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)