### PR TITLE
feat: post-extraction VLM QA findings UI (+ result viewer/sidebar polish)

### DIFF
--- a/src/components/DocumentRoutingPanel.tsx
+++ b/src/components/DocumentRoutingPanel.tsx
@@ -611,8 +611,8 @@ export default function DocumentRoutingPanel({
       {sections.length === 0 ? (
         <div className="text-sm text-gray-500 italic px-2">
           No sections detected. Every page was classified as &quot;none&quot;
-          (boilerplate / empty / unrelated) — extraction will run on the full
-          document instead.
+          (boilerplate / empty / unrelated) — nothing was extracted. The file
+          has no extractable content.
         </div>
       ) : (
         <Collapse

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -1833,9 +1833,9 @@ const FileTable: React.FC<FileTableProps> = ({
       },
     },
     {
-      title: "Actions",
+      title: "",
       key: "actions",
-      width: 60,
+      width: 20,
       fixed: "right" as const,
       render: (_: any, record: JobFile) => {
         const menuItems = [];
@@ -2095,19 +2095,18 @@ const FileTable: React.FC<FileTableProps> = ({
             </div>
             <div className="text-xs text-gray-500">Pending</div>
           </div>
-          {fileSummary?.total_records != null && fileSummary.total_records > 0 && (
-            <>
-              <div className="w-px h-4 bg-gray-200" />
-              <div className="text-center flex space-x-2 items-center">
-                <div className="text-sm font-semibold text-purple-600">
-                  {fileSummary.total_records}
+          {fileSummary?.total_records != null &&
+            fileSummary.total_records > 0 && (
+              <>
+                <div className="w-px h-4 bg-gray-200" />
+                <div className="text-center flex space-x-2 items-center">
+                  <div className="text-sm font-semibold text-purple-600">
+                    {fileSummary.total_records}
+                  </div>
+                  <div className="text-xs text-gray-500">Records</div>
                 </div>
-                <div className="text-xs text-gray-500">
-                  Records
-                </div>
-              </div>
-            </>
-          )}
+              </>
+            )}
         </div>
         <div className="flex items-center gap-2">
           {/* Phase 6: Search input */}

--- a/src/components/jobs/JobJobsRail.tsx
+++ b/src/components/jobs/JobJobsRail.tsx
@@ -328,7 +328,7 @@ export default function JobJobsRail({ currentJobId, jobName }: JobJobsRailProps)
 
       {/* Desktop: sticky rail */}
       <aside
-        className={`hidden lg:flex flex-shrink-0 flex-col border-r border-gray-200 bg-white sticky top-0 self-start max-h-[calc(100vh-4rem)] transition-[width] duration-200 ease-out ${
+        className={`hidden lg:flex flex-shrink-0 flex-col border-r border-gray-200 bg-white sticky top-0 self-start max-h-[calc(100vh-2.75rem)] transition-[width] duration-200 ease-out ${
           collapsed ? "w-12" : "w-[17rem]"
         }`}
         aria-label="Jobs sidebar"

--- a/src/components/layout/SidebarLayout.tsx
+++ b/src/components/layout/SidebarLayout.tsx
@@ -16,13 +16,14 @@ import {
   Menu,
   X,
   ChevronDown,
-  ChevronLeft,
-  ChevronRight,
   Settings,
   Upload,
   Library,
   Building2,
   Activity,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Layers,
 } from "lucide-react";
 import OrganizationSelector from "@/components/organization/OrganizationSelector";
 import CreateOrganizationModal from "@/components/organization/CreateOrganizationModal";
@@ -35,7 +36,14 @@ interface SidebarLayoutProps {
   headerContent?: React.ReactNode;
 }
 
-const mainNavigationItems = [
+type NavItem = {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  description: string;
+};
+
+const mainNavigationItems: NavItem[] = [
   {
     name: "Dashboard",
     href: "/",
@@ -62,8 +70,7 @@ const mainNavigationItems = [
   },
 ];
 
-/** Shown in an "Admin" group for admin JWTs only. */
-const adminNavItems = [
+const adminNavItems: NavItem[] = [
   {
     name: "Schema registry",
     href: "/registry",
@@ -101,7 +108,9 @@ export default function SidebarLayout({
     pageTitle ||
     mainNavigationItems.find((item) => item.href === pathname)?.name ||
     adminNavItems.find((item) =>
-      item.href !== "/" ? pathname === item.href || pathname?.startsWith(item.href + "/") : pathname === item.href
+      item.href !== "/"
+        ? pathname === item.href || pathname?.startsWith(item.href + "/")
+        : pathname === item.href,
     )?.name;
 
   useEffect(() => {
@@ -187,10 +196,11 @@ export default function SidebarLayout({
       ? pathname === href || pathname?.startsWith(href + "/")
       : pathname === href;
 
-  const renderNavLink = (item: (typeof mainNavigationItems)[0]) => {
+  const sidebarCollapsed = isDesktop && isCollapsed;
+
+  const renderNavLink = (item: NavItem) => {
     const isActive = navLinkIsActive(item.href);
     const Icon = item.icon;
-    const collapsed = isDesktop && isCollapsed;
 
     return (
       <Link
@@ -198,32 +208,27 @@ export default function SidebarLayout({
         href={item.href}
         onClick={closeSidebar}
         aria-current={isActive ? "page" : undefined}
-        title={collapsed ? item.name : undefined}
-        className={`group flex items-center text-sm font-medium rounded-lg transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
-          collapsed ? "justify-center px-2 py-3" : "px-3 py-2.5"
+        title={sidebarCollapsed ? item.name : item.description}
+        className={`group flex items-center rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
+          sidebarCollapsed
+            ? "justify-center p-2"
+            : "gap-2 px-2 py-1.5 text-[13px]"
         } ${
           isActive
-            ? "bg-blue-50 text-blue-800 border border-blue-200 shadow-sm"
-            : "text-gray-700 hover:bg-gray-50 hover:text-gray-900 border border-transparent"
+            ? "bg-zinc-800 text-zinc-100"
+            : "text-zinc-400 hover:bg-zinc-800/70 hover:text-zinc-200"
         }`}
       >
         <Icon
-          className={`h-5 w-5 transition-colors flex-shrink-0 ${
-            collapsed ? "" : "mr-3"
-          } ${
+          className={`h-4 w-4 flex-shrink-0 ${
             isActive
-              ? "text-blue-600"
-              : "text-gray-400 group-hover:text-gray-600"
+              ? "text-emerald-400"
+              : "text-zinc-500 group-hover:text-zinc-300"
           }`}
           aria-hidden
         />
-        {(!isDesktop || !isCollapsed) && (
-          <div className="flex-1 min-w-0">
-            <div className="font-medium">{item.name}</div>
-            <div className="text-xs text-gray-500 line-clamp-2">
-              {item.description}
-            </div>
-          </div>
+        {!sidebarCollapsed && (
+          <span className="truncate font-medium">{item.name}</span>
         )}
       </Link>
     );
@@ -253,183 +258,148 @@ export default function SidebarLayout({
         initial={false}
         animate={{
           x: isDesktop ? 0 : isSidebarOpen ? 0 : "-100%",
-          width:
-            isDesktop && isCollapsed ? "4rem" : isDesktop ? "18rem" : "18rem",
         }}
         transition={{ type: "spring", damping: 28, stiffness: 260 }}
-        className={`fixed inset-y-0 left-0 z-50 bg-white border-r border-gray-200 shadow-sm lg:relative lg:translate-x-0 lg:block lg:h-screen lg:shadow-none sidebar-desktop ${
-          isDesktop && isCollapsed ? "w-16" : "w-72"
-        }`}
+        className={`fixed inset-y-0 left-0 z-50 flex-shrink-0 border-r border-zinc-800 bg-zinc-950 lg:relative lg:translate-x-0 lg:block lg:h-screen sidebar-desktop transition-[width] duration-200 ease-out ${
+          sidebarCollapsed ? "w-12" : "w-[13.5rem]"
+        } ${!isDesktop ? "w-[13.5rem]" : ""}`}
       >
         <div className="flex h-full flex-col overflow-hidden">
+          {/* Brand + collapse */}
           <div
-            className={`flex h-16 items-center justify-between border-b border-gray-200 flex-shrink-0 gap-2 ${
-              isDesktop && isCollapsed ? "px-2" : "pl-4 pr-3"
+            className={`flex h-11 shrink-0 items-center overflow-hidden border-b border-zinc-800/80 ${
+              sidebarCollapsed ? "justify-center px-1.5" : "px-2 gap-1"
             }`}
           >
-            <Link
-              href="/"
-              onClick={closeSidebar}
-              className={`flex items-center min-w-0 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
-                isDesktop && isCollapsed ? "justify-center p-1.5" : "space-x-3 py-1"
-              }`}
-              aria-label="Core Extract — Home"
-            >
-              <div className="w-9 h-9 bg-gradient-to-br from-blue-600 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0 shadow-sm">
-                <span className="text-white font-bold text-sm">CE</span>
-              </div>
-              {(!isDesktop || !isCollapsed) && (
-                <div className="min-w-0">
-                  <span className="text-lg font-bold text-gray-900 truncate block">
-                    Core Extract
-                  </span>
-                  <div className="text-xs text-gray-500 truncate">
-                    Document AI Platform
-                  </div>
-                </div>
-              )}
-            </Link>
-            <div className="flex items-center flex-shrink-0 gap-0.5">
-              {isDesktop && (
-                <button
-                  type="button"
-                  onClick={toggleCollapse}
-                  className="p-2 rounded-lg hover:bg-gray-100 transition-colors text-gray-500 hover:text-gray-800"
-                  title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  aria-expanded={!isCollapsed}
-                  aria-controls="app-sidebar"
-                  aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-                >
-                  {isCollapsed ? (
-                    <ChevronRight className="h-5 w-5" />
-                  ) : (
-                    <ChevronLeft className="h-5 w-5" />
-                  )}
-                </button>
-              )}
-              <button
-                type="button"
+            {sidebarCollapsed ? (
+              <Link
+                href="/"
                 onClick={closeSidebar}
-                className="lg:hidden p-2 rounded-lg hover:bg-gray-100 text-gray-500"
-                aria-label="Close menu"
+                className="flex items-center justify-center p-2 rounded-md hover:bg-zinc-800/70 transition-colors"
+                aria-label="Core Extract — Home"
               >
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-          </div>
-
-          <div
-            className={`border-b border-gray-200 flex-shrink-0 ${
-              isDesktop && isCollapsed ? "px-2 py-3 flex justify-center" : "px-4 py-3"
-            }`}
-          >
-            {isDesktop && isCollapsed ? (
-              <OrganizationSelector
-                compact
-                onCreateOrganization={
-                  isAdmin ? () => setIsCreateOrgModalOpen(true) : undefined
-                }
-              />
+                <div className="w-6 h-6 rounded-md bg-emerald-600 flex items-center justify-center flex-shrink-0">
+                  <Layers className="h-3.5 w-3.5 text-white" aria-hidden />
+                </div>
+              </Link>
             ) : (
               <>
-                <div className="mb-2">
-                  <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Organization
-                  </label>
-                </div>
-                <OrganizationSelector
-                  onCreateOrganization={
-                    isAdmin ? () => setIsCreateOrgModalOpen(true) : undefined
-                  }
-                />
+                <Link
+                  href="/"
+                  onClick={closeSidebar}
+                  className="flex items-center gap-2 min-w-0 flex-1 rounded-md px-1 py-1 hover:bg-zinc-800/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+                  aria-label="Core Extract — Home"
+                >
+                  <div className="w-6 h-6 rounded-md bg-emerald-600 flex items-center justify-center flex-shrink-0">
+                    <Layers className="h-3.5 w-3.5 text-white" aria-hidden />
+                  </div>
+                  <span className="text-xs font-semibold text-zinc-100 truncate">
+                    Core Extract
+                  </span>
+                </Link>
+                {isDesktop ? (
+                  <button
+                    type="button"
+                    onClick={toggleCollapse}
+                    className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 transition-colors flex-shrink-0"
+                    title="Collapse sidebar"
+                    aria-expanded
+                    aria-controls="app-sidebar"
+                    aria-label="Collapse sidebar"
+                  >
+                    <PanelLeftClose className="h-4 w-4" aria-hidden />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={closeSidebar}
+                    className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 lg:hidden"
+                    aria-label="Close menu"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
               </>
             )}
           </div>
 
+          {/* Organization */}
+          <div
+            className={`border-b border-zinc-800/80 flex-shrink-0 ${
+              sidebarCollapsed
+                ? "px-1.5 py-1.5 flex justify-center"
+                : "px-2 py-2"
+            }`}
+          >
+            <OrganizationSelector
+              compact={sidebarCollapsed}
+              tone="dark"
+              className={sidebarCollapsed ? "w-full flex justify-center" : ""}
+              onCreateOrganization={
+                isAdmin ? () => setIsCreateOrgModalOpen(true) : undefined
+              }
+            />
+          </div>
+
           <nav
-            className={`flex-1 py-4 space-y-4 overflow-y-auto overflow-x-hidden [scrollbar-width:thin] [scrollbar-color:rgb(203_213_225)_transparent] ${
-              isDesktop && isCollapsed ? "px-2" : "px-3"
+            className={`flex-1 py-2 space-y-3 overflow-y-auto overflow-x-hidden [scrollbar-width:thin] [scrollbar-color:rgb(63_63_70)_transparent] ${
+              sidebarCollapsed ? "px-1.5" : "px-2"
             }`}
             aria-label="Main navigation"
           >
-            <div className="space-y-1">
-              {(!isDesktop || !isCollapsed) && (
-                <p className="px-3 text-[11px] font-semibold uppercase tracking-wider text-gray-400">
-                  Navigate
+            <div className="space-y-0.5">
+              {!sidebarCollapsed && (
+                <p className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wider text-zinc-500">
+                  Project
                 </p>
               )}
               {mainNavigationItems.map(renderNavLink)}
             </div>
 
             {isAdmin && (
-              <div className="space-y-1 pt-2 border-t border-gray-100">
-                {(!isDesktop || !isCollapsed) && (
-                  <p className="px-3 text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+              <div className="space-y-0.5 pt-2 border-t border-zinc-800/80">
+                {!sidebarCollapsed && (
+                  <p className="px-2 pb-1 text-[10px] font-medium uppercase tracking-wider text-zinc-500">
                     Admin
                   </p>
                 )}
-                {adminNavItems.map((item) => {
-                  const isActive = navLinkIsActive(item.href);
-                  const Icon = item.icon;
-                  const collapsed = isDesktop && isCollapsed;
-                  return (
-                    <Link
-                      key={item.name}
-                      href={item.href}
-                      onClick={closeSidebar}
-                      aria-current={isActive ? "page" : undefined}
-                      title={collapsed ? item.name : undefined}
-                      className={`group flex items-center text-sm font-medium rounded-lg transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
-                        collapsed ? "justify-center px-2 py-3" : "px-3 py-2.5"
-                      } ${
-                        isActive
-                          ? "bg-violet-50 text-violet-900 border border-violet-200 shadow-sm"
-                          : "text-gray-700 hover:bg-gray-50 hover:text-gray-900 border border-transparent"
-                      }`}
-                    >
-                      <Icon
-                        className={`h-5 w-5 flex-shrink-0 ${
-                          collapsed ? "" : "mr-3"
-                        } ${
-                          isActive
-                            ? "text-violet-600"
-                            : "text-gray-400 group-hover:text-gray-600"
-                        }`}
-                        aria-hidden
-                      />
-                      {(!isDesktop || !isCollapsed) && (
-                        <div className="flex-1 min-w-0">
-                          <div className="font-medium">{item.name}</div>
-                          <div className="text-xs text-gray-500 line-clamp-2">
-                            {item.description}
-                          </div>
-                        </div>
-                      )}
-                    </Link>
-                  );
-                })}
+                {adminNavItems.map(renderNavLink)}
               </div>
             )}
           </nav>
 
+          {/* Account */}
           <div
             ref={userMenuRef}
-            className={`border-t border-gray-200 flex-shrink-0 relative ${
-              isDesktop && isCollapsed ? "p-2" : "p-3"
+            className={`border-t border-zinc-800/80 flex-shrink-0 relative ${
+              sidebarCollapsed ? "p-1.5" : "p-2"
             }`}
           >
-            {isDesktop && isCollapsed ? (
-              <div className="flex flex-col items-center">
+            {sidebarCollapsed ? (
+              <div className="flex flex-col items-center gap-1">
+                {isDesktop && (
+                  <button
+                    type="button"
+                    onClick={toggleCollapse}
+                    className="flex items-center justify-center p-2 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                    title="Expand sidebar"
+                    aria-expanded={false}
+                    aria-controls="app-sidebar"
+                    aria-label="Expand sidebar"
+                  >
+                    <PanelLeftOpen className="h-4 w-4" aria-hidden />
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
-                  className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center hover:opacity-90 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                  className="flex items-center justify-center p-2 rounded-md hover:bg-zinc-800/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
                   title={user?.name || "Account menu"}
                   aria-haspopup="menu"
                   aria-expanded={isUserMenuOpen}
                   aria-label="Account menu"
                 >
-                  <span className="text-white font-medium text-sm">
+                  <span className="w-6 h-6 bg-zinc-800 border border-zinc-700 rounded-md flex items-center justify-center text-zinc-200 font-medium text-xs">
                     {user?.name?.charAt(0).toUpperCase()}
                   </span>
                 </button>
@@ -479,28 +449,28 @@ export default function SidebarLayout({
                 <button
                   type="button"
                   onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
-                  className="flex w-full items-center justify-between rounded-lg p-2 hover:bg-gray-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                  className="flex w-full items-center justify-between rounded-md px-1.5 py-1.5 hover:bg-zinc-800/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
                   aria-haspopup="menu"
                   aria-expanded={isUserMenuOpen}
                   aria-label="Account menu"
                 >
-                  <div className="flex items-center space-x-3 min-w-0">
-                    <div className="w-9 h-9 bg-gradient-to-br from-blue-500 to-purple-500 rounded-full flex items-center justify-center flex-shrink-0">
-                      <span className="text-white font-medium text-sm">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <div className="w-7 h-7 bg-zinc-800 border border-zinc-700 rounded-md flex items-center justify-center flex-shrink-0">
+                      <span className="text-zinc-200 font-medium text-xs">
                         {user?.name?.charAt(0).toUpperCase()}
                       </span>
                     </div>
                     <div className="text-left min-w-0">
-                      <div className="text-sm font-medium text-gray-900 truncate">
+                      <div className="text-xs font-medium text-zinc-100 truncate">
                         {user?.name}
                       </div>
-                      <div className="text-xs text-gray-500 truncate max-w-[12rem]">
+                      <div className="text-[10px] text-zinc-500 truncate max-w-[9rem]">
                         {user?.email}
                       </div>
                     </div>
                   </div>
                   <ChevronDown
-                    className={`h-4 w-4 text-gray-400 flex-shrink-0 transition-transform ${
+                    className={`h-3.5 w-3.5 text-zinc-500 flex-shrink-0 transition-transform ${
                       isUserMenuOpen ? "rotate-180" : ""
                     }`}
                     aria-hidden
@@ -513,7 +483,7 @@ export default function SidebarLayout({
                       initial={{ opacity: 0, y: 8 }}
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, y: 8 }}
-                      className="absolute bottom-full left-0 right-0 mb-2 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-[55]"
+                      className="absolute bottom-full left-2 right-2 mb-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-[55]"
                       role="menu"
                     >
                       <Link
@@ -554,16 +524,16 @@ export default function SidebarLayout({
       </motion.aside>
 
       <div className="flex-1 flex flex-col min-h-screen min-w-0 main-content">
-        <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-3 bg-white/95 backdrop-blur-sm border-b border-gray-200 px-4 sm:px-6 supports-[backdrop-filter]:bg-white/85">
+        <header className="sticky top-0 z-30 flex h-11 items-center justify-between gap-2 bg-white/95 backdrop-blur-sm border-b border-gray-200 px-3 sm:px-4 supports-[backdrop-filter]:bg-white/85">
           <button
             type="button"
             onClick={toggleSidebar}
-            className="lg:hidden p-2 rounded-lg hover:bg-gray-100 text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="lg:hidden p-1.5 rounded-md hover:bg-gray-100 text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
             aria-label="Open navigation menu"
             aria-expanded={isSidebarOpen}
             aria-controls="app-sidebar"
           >
-            <Menu className="h-5 w-5" />
+            <Menu className="h-4 w-4" />
           </button>
 
           <div className="flex items-center min-w-0 flex-1">
@@ -571,14 +541,14 @@ export default function SidebarLayout({
               headerContent
             ) : (
               <div className="min-w-0 hidden sm:block">
-                <h1 className="text-lg font-semibold text-gray-900 truncate">
+                <h1 className="text-sm font-semibold text-gray-900 truncate leading-tight">
                   {pageTitle ||
                     mainNavigationItems.find((item) => item.href === pathname)
                       ?.name ||
                     "Dashboard"}
                 </h1>
                 {pageDescription && (
-                  <p className="text-sm text-gray-500 line-clamp-1">
+                  <p className="text-xs text-gray-500 line-clamp-1">
                     {pageDescription}
                   </p>
                 )}
@@ -586,18 +556,18 @@ export default function SidebarLayout({
             )}
           </div>
 
-          <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="flex items-center gap-2 flex-shrink-0">
             {headerActions ||
               (currentOrganization && (
                 <div
-                  className="hidden sm:flex items-center gap-2 max-w-[14rem] xl:max-w-xs rounded-full border border-gray-200 bg-gray-50/80 px-3 py-1.5"
+                  className="hidden sm:flex items-center gap-1.5 max-w-[12rem] xl:max-w-[16rem] rounded-md border border-gray-200 bg-gray-50/90 px-2 py-1"
                   title={currentOrganization.name}
                 >
                   <Building2
-                    className="h-4 w-4 text-gray-500 flex-shrink-0"
+                    className="h-3.5 w-3.5 text-gray-500 flex-shrink-0"
                     aria-hidden
                   />
-                  <span className="text-sm text-gray-700 truncate">
+                  <span className="text-xs text-gray-700 truncate">
                     {currentOrganization.name}
                   </span>
                 </div>
@@ -605,7 +575,7 @@ export default function SidebarLayout({
           </div>
         </header>
 
-        <main className="flex-1 p-6 overflow-y-auto">{children}</main>
+        <main className="flex-1 p-4 sm:p-5 overflow-y-auto">{children}</main>
       </div>
 
       <CreateOrganizationModal

--- a/src/components/organization/OrganizationSelector.tsx
+++ b/src/components/organization/OrganizationSelector.tsx
@@ -14,13 +14,17 @@ interface OrganizationSelectorProps {
   onCreateOrganization?: () => void;
   /** Icon-only control for narrow / collapsed sidebars — same org list + create (admins). */
   compact?: boolean;
+  /** Matches dark app sidebar (Supabase-style). */
+  tone?: "light" | "dark";
 }
 
 export default function OrganizationSelector({
   className = "",
   onCreateOrganization,
   compact = false,
+  tone = "light",
 }: OrganizationSelectorProps) {
+  const isDark = tone === "dark";
   const {
     currentOrganization,
     organizations,
@@ -243,14 +247,22 @@ export default function OrganizationSelector({
           ref={triggerRef}
           type="button"
           onClick={() => setIsOpen(!isOpen)}
-          className="relative w-10 h-10 flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100 hover:border-gray-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+          className={`relative w-8 h-8 flex items-center justify-center rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 ${
+            isDark
+              ? "border border-zinc-700/80 bg-zinc-800/80 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600"
+              : "border border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100 hover:border-gray-300 focus-visible:ring-blue-500 focus-visible:ring-offset-white"
+          }`}
           title={currentOrganization?.name || "Organization"}
           aria-label={`Organization: ${currentOrganization?.name || "Select"}. ${isOpen ? "Close menu" : "Open menu"}`}
           aria-expanded={isOpen}
           aria-haspopup="listbox"
         >
-          <Building2 className="h-5 w-5" aria-hidden />
-          <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-green-500 ring-2 ring-white" />
+          <Building2 className="h-4 w-4" aria-hidden />
+          <span
+            className={`absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-emerald-500 ring-2 ${
+              isDark ? "ring-zinc-900" : "ring-white"
+            }`}
+          />
         </button>
         {compactMenu}
       </div>
@@ -260,37 +272,71 @@ export default function OrganizationSelector({
   return (
     <div ref={rootRef} className={className}>
       <div className="relative">
-        <Button
-          variant="secondary"
-          onClick={() => setIsOpen(!isOpen)}
-          className="w-full justify-between"
-          aria-expanded={isOpen}
-          aria-haspopup="listbox"
-          aria-label="Select organization"
-        >
-          <div className="flex items-center space-x-2 min-w-0">
-            <div className="w-2 h-2 bg-green-500 rounded-full flex-shrink-0" />
-            <span className="truncate">
-              {currentOrganization?.name || "Select Organization"}
-            </span>
-          </div>
-          <svg
-            className={`w-4 h-4 transition-transform flex-shrink-0 ${
-              isOpen ? "rotate-180" : ""
-            }`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden
+        {isDark ? (
+          <button
+            type="button"
+            onClick={() => setIsOpen(!isOpen)}
+            className="w-full flex items-center justify-between gap-2 rounded-md border border-zinc-700/80 bg-zinc-800/60 px-2 py-1.5 text-left text-xs text-zinc-200 hover:bg-zinc-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+            aria-expanded={isOpen}
+            aria-haspopup="listbox"
+            aria-label="Select organization"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </Button>
+            <div className="flex items-center gap-1.5 min-w-0">
+              <span className="w-1.5 h-1.5 bg-emerald-500 rounded-full flex-shrink-0" />
+              <span className="truncate font-medium">
+                {currentOrganization?.name || "Organization"}
+              </span>
+            </div>
+            <svg
+              className={`w-3.5 h-3.5 text-zinc-500 flex-shrink-0 transition-transform ${
+                isOpen ? "rotate-180" : ""
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+        ) : (
+          <Button
+            variant="secondary"
+            onClick={() => setIsOpen(!isOpen)}
+            className="w-full justify-between"
+            aria-expanded={isOpen}
+            aria-haspopup="listbox"
+            aria-label="Select organization"
+          >
+            <div className="flex items-center space-x-2 min-w-0">
+              <div className="w-2 h-2 bg-green-500 rounded-full flex-shrink-0" />
+              <span className="truncate">
+                {currentOrganization?.name || "Select Organization"}
+              </span>
+            </div>
+            <svg
+              className={`w-4 h-4 transition-transform flex-shrink-0 ${
+                isOpen ? "rotate-180" : ""
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </Button>
+        )}
 
         {isOpen && (
           <div

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -7,7 +7,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { jsonToCsv } from "@/lib/csvExport";
 import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
-import { App, Button, Input, Select, Typography } from "antd";
+import { App, Button, Input, Popconfirm, Select, Typography } from "antd";
 import { JsonViewer } from "@/components/json";
 import {
   apiClient,
@@ -374,50 +374,91 @@ function SectionVerifyControls({
       <span className="w-px h-4 bg-gray-200" />
       <div className="flex items-center gap-0.5">
         {currentStatus !== "approved" && (
-          <button
-            type="button"
+          <Popconfirm
+            title="Approve this section?"
+            description="Mark this section as approved for review."
+            okText="Approve"
+            cancelText="Cancel"
             disabled={loading}
-            onClick={() => onVerify("approved")}
-            className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-green-700 hover:bg-green-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
-            title="Approve this section"
+            onConfirm={() => onVerify("approved")}
           >
-            Approve
-          </button>
+            <span className="inline-flex">
+              <button
+                type="button"
+                disabled={loading}
+                className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-green-700 hover:bg-green-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+                title="Approve this section"
+              >
+                Approve
+              </button>
+            </span>
+          </Popconfirm>
         )}
         {currentStatus !== "rejected" && (
-          <button
-            type="button"
+          <Popconfirm
+            title="Reject this section?"
+            description="Mark this section as rejected."
+            okText="Reject"
+            cancelText="Cancel"
+            okButtonProps={{ danger: true }}
             disabled={loading}
-            onClick={() => onVerify("rejected")}
-            className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
-            title="Reject this section"
+            onConfirm={() => onVerify("rejected")}
           >
-            Reject
-          </button>
+            <span className="inline-flex">
+              <button
+                type="button"
+                disabled={loading}
+                className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-red-700 hover:bg-red-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+                title="Reject this section"
+              >
+                Reject
+              </button>
+            </span>
+          </Popconfirm>
         )}
         {currentStatus !== "pending" && (
-          <button
-            type="button"
+          <Popconfirm
+            title="Reset verification?"
+            description="This section will return to pending status."
+            okText="Reset"
+            cancelText="Cancel"
             disabled={loading}
-            onClick={() => onVerify("pending")}
-            className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
-            title="Reset to pending"
+            onConfirm={() => onVerify("pending")}
           >
-            Reset
-          </button>
+            <span className="inline-flex">
+              <button
+                type="button"
+                disabled={loading}
+                className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+                title="Reset to pending"
+              >
+                Reset
+              </button>
+            </span>
+          </Popconfirm>
         )}
         {onBulkApprove && !allApproved && totalSections > 1 && (
           <>
             <span className="w-px h-3.5 bg-gray-200 mx-0.5" />
-            <button
-              type="button"
+            <Popconfirm
+              title={`Approve all ${totalSections} sections?`}
+              description="Every section in this file will be marked approved."
+              okText="Approve all"
+              cancelText="Cancel"
               disabled={loading}
-              onClick={onBulkApprove}
-              className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-green-700 hover:bg-green-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
-              title={`Approve all ${totalSections} sections`}
+              onConfirm={onBulkApprove}
             >
-              Approve all
-            </button>
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  disabled={loading}
+                  className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-green-700 hover:bg-green-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+                  title={`Approve all ${totalSections} sections`}
+                >
+                  Approve all
+                </button>
+              </span>
+            </Popconfirm>
           </>
         )}
       </div>
@@ -897,11 +938,66 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
           <span className="text-xs text-gray-400 whitespace-nowrap tabular-nums">
             {selectedSectionIdx + 1} / {sectionEntries.length}
           </span>
+        </div>
+      )}
 
-          {/* Verification controls */}
-          {onSectionVerify && selectedSection?.sectionResultId && (
+      {/* QA + verification — below section picker; section row is navigation only */}
+      {isV2 &&
+        selectedSection?.sectionResultId &&
+        (fileId || onSectionVerify) && (
+        <div className="flex flex-wrap items-center gap-2 px-3 py-1.5 border-b border-gray-100 bg-gray-50 flex-shrink-0">
+          {fileId && (
             <>
-              <span className="w-px h-5 bg-gray-200 mx-1" />
+              <span className="text-[10px] text-gray-400 uppercase tracking-wide font-medium">
+                QA
+              </span>
+              <div className="flex items-center gap-0.5">
+                <Popconfirm
+                  title="Run QA on this section?"
+                  description="Analyzes the current section's extracted data. This may take a moment."
+                  okText="Run QA"
+                  cancelText="Cancel"
+                  disabled={qaLoading !== "idle"}
+                  onConfirm={handleRunSectionQA}
+                >
+                  <span className="inline-flex">
+                    <button
+                      type="button"
+                      disabled={qaLoading !== "idle"}
+                      className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-blue-700 hover:bg-blue-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+                    >
+                      {qaLoading === "section"
+                        ? "Running…"
+                        : openFindingsCount > 0
+                          ? `Run QA · ${openFindingsCount} open`
+                          : "Run QA"}
+                    </button>
+                  </span>
+                </Popconfirm>
+                <Popconfirm
+                  title="Run QA on all sections?"
+                  description="Analyzes every section in this file. This may take longer."
+                  okText="Run all"
+                  cancelText="Cancel"
+                  disabled={qaLoading !== "idle"}
+                  onConfirm={handleRunAllQA}
+                >
+                  <span className="inline-flex">
+                    <button
+                      type="button"
+                      disabled={qaLoading !== "idle"}
+                      className="px-1.5 py-0.5 text-[10px] text-gray-500 hover:text-blue-700 hover:bg-blue-50 rounded transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+                    >
+                      {qaLoading === "all" ? "Running…" : "Run all sections"}
+                    </button>
+                  </span>
+                </Popconfirm>
+              </div>
+            </>
+          )}
+          {onSectionVerify && (
+            <>
+              {fileId && <span className="w-px h-5 bg-gray-200" />}
               <SectionVerifyControls
                 verification={selectedVerification}
                 loading={verifyLoading}
@@ -917,30 +1013,6 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
               />
             </>
           )}
-
-        </div>
-      )}
-
-      {/* QA action bar — separate row below section picker, only when section selected */}
-      {isV2 && fileId && selectedSection?.sectionResultId && (
-        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-gray-100 bg-gray-50 flex-shrink-0">
-          <span className="text-xs text-gray-400 uppercase tracking-wide font-medium">QA</span>
-          <Button
-            size="small"
-            loading={qaLoading === 'section'}
-            disabled={qaLoading !== 'idle'}
-            onClick={handleRunSectionQA}
-          >
-            {openFindingsCount > 0 ? `Run QA · ${openFindingsCount} open` : 'Run QA'}
-          </Button>
-          <Button
-            size="small"
-            loading={qaLoading === 'all'}
-            disabled={qaLoading !== 'idle'}
-            onClick={handleRunAllQA}
-          >
-            Run all sections
-          </Button>
         </div>
       )}
 

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -231,6 +231,102 @@ const VERIFY_STATUS_CONFIG: Record<
   },
 };
 
+// ── QA Findings Panel ──────────────────────────────────────────────
+
+const SEVERITY_CONFIG = {
+  error:   { icon: '❌', bg: 'bg-red-50',    border: 'border-red-200',    text: 'text-red-800'    },
+  warning: { icon: '⚠️', bg: 'bg-amber-50',  border: 'border-amber-200',  text: 'text-amber-800'  },
+  info:    { icon: 'ℹ️', bg: 'bg-blue-50',   border: 'border-blue-200',   text: 'text-blue-800'   },
+} as const;
+
+function QAFindingsPanel({
+  findings,
+  onUpdate,
+}: {
+  findings: import("@/lib/api").QAFinding[];
+  onUpdate: (findingId: string, status: 'accepted' | 'dismissed') => Promise<void>;
+}) {
+  const [updating, setUpdating] = useState<string | null>(null);
+  const open = findings.filter(f => f.status === 'open');
+  const resolved = findings.filter(f => f.status !== 'open');
+  const [showResolved, setShowResolved] = useState(false);
+
+  const handleAction = async (findingId: string, status: 'accepted' | 'dismissed') => {
+    setUpdating(findingId);
+    try { await onUpdate(findingId, status); } finally { setUpdating(null); }
+  };
+
+  const renderFinding = (f: import("@/lib/api").QAFinding) => {
+    const cfg = SEVERITY_CONFIG[f.severity] ?? SEVERITY_CONFIG.info;
+    const isResolved = f.status !== 'open';
+    return (
+      <div key={f.id} className={`rounded-md border px-3 py-2 ${cfg.bg} ${cfg.border} ${isResolved ? 'opacity-60' : ''}`}>
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <span>{cfg.icon}</span>
+              <code className="text-xs font-mono font-semibold text-gray-800 break-all">{f.field_path}</code>
+              <span className={`text-xs ${cfg.text} capitalize`}>{f.issue_type.replace(/_/g, ' ')}</span>
+            </div>
+            {(f.expected || f.actual) && (
+              <div className="mt-1 text-xs text-gray-600 space-y-0.5">
+                {f.expected && <div><span className="font-medium">Expected:</span> {f.expected}</div>}
+                {f.actual   && <div><span className="font-medium">Actual:</span>   {f.actual}</div>}
+              </div>
+            )}
+            <p className="mt-1 text-xs text-gray-500 italic">{f.explanation}</p>
+          </div>
+          {!isResolved && (
+            <div className="flex gap-1 flex-shrink-0">
+              <button
+                disabled={updating === f.id}
+                onClick={() => handleAction(f.id, 'accepted')}
+                className="text-xs text-green-700 hover:underline disabled:opacity-50"
+              >Accept</button>
+              <span className="text-gray-300">|</span>
+              <button
+                disabled={updating === f.id}
+                onClick={() => handleAction(f.id, 'dismissed')}
+                className="text-xs text-gray-500 hover:underline disabled:opacity-50"
+              >Dismiss</button>
+            </div>
+          )}
+          {isResolved && (
+            <span className={`text-xs px-1.5 py-0.5 rounded-full capitalize ${f.status === 'accepted' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
+              {f.status}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex-shrink-0 border-t border-gray-200 bg-white px-3 py-2 space-y-2 max-h-64 overflow-y-auto">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
+          QA Findings {open.length > 0 && <span className="text-red-600 ml-1">({open.length} open)</span>}
+        </span>
+        {resolved.length > 0 && (
+          <button
+            onClick={() => setShowResolved(v => !v)}
+            className="text-xs text-gray-400 hover:text-gray-600"
+          >
+            {showResolved ? 'Hide resolved' : `Show resolved (${resolved.length})`}
+          </button>
+        )}
+      </div>
+      {open.length === 0 && (
+        <p className="text-xs text-gray-400 italic">No open issues — all clear ✅</p>
+      )}
+      <div className="space-y-1.5">
+        {open.map(renderFinding)}
+        {showResolved && resolved.map(renderFinding)}
+      </div>
+    </div>
+  );
+}
+
 function SectionVerifyControls({
   verification,
   loading,
@@ -439,6 +535,92 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
     },
     [sectionEntries, onBulkSectionVerify, message],
   );
+
+  // ── QA state ──────────────────────────────────────────────────────
+  // Findings are loaded per-file on mount, then refreshed after a QA run.
+  const [qaFindings, setQaFindings] = useState<Record<string, import("@/lib/api").QAFinding[]>>({});
+  const [qaLoading, setQaLoading] = useState<'idle' | 'section' | 'all'>('idle');
+
+  // Load existing findings when the component mounts or fileId changes
+  useEffect(() => {
+    if (!fileId) return;
+    apiClient.getQAFindings(fileId).then((res) => {
+      if (res.status === 'success' && res.findings) {
+        setQaFindings(res.findings);
+      }
+    }).catch(() => {/* non-fatal */});
+  }, [fileId]);
+
+  // Findings for the currently selected section
+  const selectedSectionFindings = useMemo(() => {
+    if (!selectedSection?.sectionResultId) return [];
+    return qaFindings[selectedSection.sectionResultId] ?? [];
+  }, [qaFindings, selectedSection?.sectionResultId]);
+
+  const openFindingsCount = useMemo(() =>
+    selectedSectionFindings.filter(f => f.status === 'open').length,
+    [selectedSectionFindings]
+  );
+
+  const handleRunSectionQA = useCallback(async () => {
+    if (!fileId || !selectedSection?.sectionResultId) return;
+    setQaLoading('section');
+    try {
+      const res = await apiClient.runSectionQA(fileId, selectedSection.sectionResultId);
+      if (res.status === 'success' && res.findings) {
+        const id = selectedSection.sectionResultId;
+        setQaFindings(prev => ({ ...prev, [id]: res.findings }));
+        const count = res.findings.filter((f: import("@/lib/api").QAFinding) => f.status === 'open').length;
+        message.success(`QA complete — ${count} issue${count === 1 ? '' : 's'} found`);
+      } else {
+        message.error(res.message || 'QA failed');
+      }
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'QA failed');
+    } finally {
+      setQaLoading('idle');
+    }
+  }, [fileId, selectedSection?.sectionResultId, message]);
+
+  const handleRunAllQA = useCallback(async () => {
+    if (!fileId) return;
+    setQaLoading('all');
+    try {
+      const res = await apiClient.runFileQA(fileId);
+      if (res.status === 'success') {
+        // Reload all findings from server
+        const findingsRes = await apiClient.getQAFindings(fileId);
+        if (findingsRes.status === 'success' && findingsRes.findings) {
+          setQaFindings(findingsRes.findings);
+        }
+        const total = (res as any).totalFindings ?? 0;
+        message.success(`QA complete — ${total} issue${total === 1 ? '' : 's'} found across all sections`);
+      } else {
+        message.error(res.message || 'QA failed');
+      }
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : 'QA failed');
+    } finally {
+      setQaLoading('idle');
+    }
+  }, [fileId, message]);
+
+  const handleUpdateFinding = useCallback(async (findingId: string, status: 'accepted' | 'dismissed') => {
+    if (!fileId || !selectedSection?.sectionResultId) return;
+    try {
+      const res = await apiClient.updateQAFindingStatus(fileId, findingId, status);
+      if (res.status === 'success' && res.finding) {
+        const updated = res.finding;
+        const sectionId = updated.section_result_id;
+        setQaFindings(prev => ({
+          ...prev,
+          [sectionId]: (prev[sectionId] ?? []).map(f => f.id === findingId ? updated : f),
+        }));
+      }
+    } catch {
+      message.error('Failed to update finding');
+    }
+  }, [fileId, selectedSection?.sectionResultId, message]);
 
   // The data that the data-shaped tabs (Preview, JSON, CSV, Edit) operate on.
   // When v2 we scope to the selected section so the user sees one focused
@@ -735,6 +917,30 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
               />
             </>
           )}
+
+        </div>
+      )}
+
+      {/* QA action bar — separate row below section picker, only when section selected */}
+      {isV2 && fileId && selectedSection?.sectionResultId && (
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-gray-100 bg-gray-50 flex-shrink-0">
+          <span className="text-xs text-gray-400 uppercase tracking-wide font-medium">QA</span>
+          <Button
+            size="small"
+            loading={qaLoading === 'section'}
+            disabled={qaLoading !== 'idle'}
+            onClick={handleRunSectionQA}
+          >
+            {openFindingsCount > 0 ? `Run QA · ${openFindingsCount} open` : 'Run QA'}
+          </Button>
+          <Button
+            size="small"
+            loading={qaLoading === 'all'}
+            disabled={qaLoading !== 'idle'}
+            onClick={handleRunAllQA}
+          >
+            Run all sections
+          </Button>
         </div>
       )}
 
@@ -865,6 +1071,14 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
                 saving={isSaving}
               />
             </div>
+          )}
+
+          {/* QA Findings Panel — shown below the JSON editor when section is selected */}
+          {activeTab === "results" && isV2 && selectedSection?.sectionResultId && selectedSectionFindings.length > 0 && (
+            <QAFindingsPanel
+              findings={selectedSectionFindings}
+              onUpdate={handleUpdateFinding}
+            />
           )}
 
           {activeTab === "markdown" && markdown && (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -331,6 +331,30 @@ export interface DetectedSections {
     edits?: Array<{ kind: string; ts: string; [k: string]: unknown }>;
 }
 
+// ── Section QA findings ──────────────────────────────────────────────
+
+export type QAIssueType = 'wrong_value' | 'missing_value' | 'extra_value' | 'missing_rows' | 'extra_rows' | 'wrong_count' | 'formatting';
+export type QASeverity = 'error' | 'warning' | 'info';
+export type QAFindingStatus = 'open' | 'accepted' | 'dismissed';
+export type QAOverallQuality = 'perfect' | 'good' | 'acceptable' | 'poor';
+
+export interface QAFinding {
+    id: string;
+    file_id: string;
+    section_result_id: string;
+    field_path: string;
+    issue_type: QAIssueType;
+    severity: QASeverity;
+    expected: string | null;
+    actual: string | null;
+    explanation: string;
+    status: QAFindingStatus;
+    overall_quality: QAOverallQuality | null;
+    qa_model: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
 // Per-section extraction (Phase 1, item #3 — v2 envelope).
 //
 // When the visual classifier is on AND it produces ≥1 section with extractable
@@ -1493,6 +1517,51 @@ class ApiClient {
             method: 'PUT',
             body: JSON.stringify({ schema }),
         });
+    }
+
+    // ── Section QA ─────────────────────────────────────────────────────
+
+    /** Run VLM QA on a single section. */
+    async runSectionQA(
+        fileId: string,
+        sectionResultId: string,
+    ): Promise<ApiResponse<{ sectionResultId: string; overall_quality: QAOverallQuality; summary: string; findings: QAFinding[] }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/sections/${encodeURIComponent(sectionResultId)}/qa`,
+            { method: 'POST' },
+        );
+    }
+
+    /** Run VLM QA on all sections in a file. */
+    async runFileQA(
+        fileId: string,
+    ): Promise<ApiResponse<{ totalSections: number; totalFindings: number; results: unknown[] }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/qa`,
+            { method: 'POST' },
+        );
+    }
+
+    /** Get all QA findings for a file, grouped by section_result_id. */
+    async getQAFindings(
+        fileId: string,
+    ): Promise<ApiResponse<{ findings: Record<string, QAFinding[]> }>> {
+        return this.request(`/files/${encodeURIComponent(fileId)}/qa-findings`);
+    }
+
+    /** Update a finding's status (accepted or dismissed). */
+    async updateQAFindingStatus(
+        fileId: string,
+        findingId: string,
+        status: 'accepted' | 'dismissed',
+    ): Promise<ApiResponse<{ finding: QAFinding }>> {
+        return this.request(
+            `/files/${encodeURIComponent(fileId)}/qa-findings/${encodeURIComponent(findingId)}`,
+            {
+                method: 'PATCH',
+                body: JSON.stringify({ status }),
+            },
+        );
     }
 
     /** Patch a single record in a V2 envelope by section_result_id. */


### PR DESCRIPTION
## What

Frontend for the post-extraction VLM QA system, plus a follow-up polish commit on the result viewer and sidebar.

## Commits

**1. `feat: post-extraction VLM QA findings UI`**
- Types: `QAFinding`, `QAIssueType`, `QASeverity`, `QAFindingStatus`, `QAOverallQuality`.
- API client: `runSectionQA`, `runFileQA`, `getQAFindings`, `updateQAFindingStatus`.
- `TabbedDataViewer`: QA action bar, findings panel below the JSON editor, accept/dismiss handling.
- Fix that made findings actually render: the QA endpoints return `{ findings | finding | totalFindings }` at the **top level** of the response, but the code read `res.data?.findings` (always `undefined`), so successful runs produced no UI. Now reads those fields directly in all four spots.

**2. `feat: compact Supabase-style sidebar and polish result viewer controls`**
- Sidebar layout / organization selector refresh and result-viewer control tweaks.

## Notes

- QA UI is **V2 only** — the action bar and findings panel are gated on `isV2 && section_result_id`; v1 files simply don't show the controls.
- Pairs with the backend PR (`feat/vlm-expectations` on text-to-structured-data → PR #25).
- ⚠️ This branch bundles the QA work with an unrelated sidebar/controls-polish commit. Happy to split them into separate PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)