### PR TITLE
feat: live processing timeline + row status chips

### DIFF
--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -20,7 +20,7 @@ import SidebarLayout from "@/components/layout/SidebarLayout";
 import { useAuth } from "@/contexts/AuthContext";
 import { useOrganization } from "@/contexts/OrganizationContext";
 import { canPerformAdminActions } from "@/utils/roleUtils";
-import { apiClient, JobDetails, JobFile } from "@/lib/api";
+import { apiClient, JobDetails, JobFile, type ProcessingEvent } from "@/lib/api";
 import PreviewSelector from "@/components/preview/PreviewSelector";
 import PreviewDrawer from "@/components/preview/PreviewDrawer";
 import InlineSchemaEditor from "@/components/InlineSchemaEditor";
@@ -233,11 +233,22 @@ function JobDetailPage() {
     [],
   );
 
+  // Latest processing-timeline event per file — drives the inline row chips.
+  const [processingEvents, setProcessingEvents] = useState<
+    Record<string, ProcessingEvent>
+  >({});
+  const handleFileProcessingEvent = useCallback((data: ProcessingEvent) => {
+    const fid = (data as any).fileId ?? (data as any).file_id;
+    if (!fid) return;
+    setProcessingEvents((prev) => ({ ...prev, [fid]: data }));
+  }, []);
+
   // WebSocket connection
   const { isConnected } = useSocket(jobId, {
     onJobStatusUpdate: handleJobStatusUpdate,
     onFileStatusUpdate: handleFileStatusUpdate,
     onPreviewUpdated: handlePreviewUpdated,
+    onFileProcessingEvent: handleFileProcessingEvent,
   });
 
   useEffect(() => {
@@ -618,6 +629,7 @@ function JobDetailPage() {
                 refreshTrigger={fileTableRefreshTrigger}
                 filePatchBatch={filePatchBatch}
                 fileSummary={fileSummary}
+                processingEvents={processingEvents}
                 isConnected={isConnected}
                 isGoingLive={isGoingLive}
                 isRefreshing={isRefreshing}

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -38,8 +38,9 @@ import {
   FileTextOutlined,
   EllipsisOutlined,
 } from "@ant-design/icons";
-import { JobFile, ProcessingConfig } from "@/lib/api";
+import { JobFile, ProcessingConfig, type ProcessingEvent } from "@/lib/api";
 import TabbedDataViewer from "@/components/ui/TabbedDataViewer";
+import ProcessingStatusChip from "@/components/file/ProcessingStatusChip";
 import { apiClient } from "@/lib/api";
 import { DEFAULT_MODELS, PROCESSING_METHODS } from "@/lib/processingConfig";
 import { useAuth } from "@/contexts/AuthContext";
@@ -95,6 +96,8 @@ interface FileTableProps {
     patch: Record<string, any>;
     version: string;
   }> | null;
+  /** Latest processing-timeline event per file id (drives inline row chips) */
+  processingEvents?: Record<string, ProcessingEvent>;
   fileSummary?: {
     total: number;
     extraction_pending: number;
@@ -144,6 +147,7 @@ const FileTable: React.FC<FileTableProps> = ({
   refreshTrigger,
   filePatchBatch,
   fileSummary,
+  processingEvents,
   isConnected = false,
   isGoingLive = false,
   isRefreshing = false,
@@ -1341,24 +1345,31 @@ const FileTable: React.FC<FileTableProps> = ({
           className="flex items-center space-x-1"
           style={{ whiteSpace: "nowrap", overflow: "hidden" }}
         >
-          {record.processing_status === "completed" &&
-            ((record as any).has_result ?? record.result) && (
-              <>
-                <Tooltip title="View results">
-                  <FullscreenOutlined
-                    style={{
-                      cursor: "pointer",
-                      color: "#1890ff",
-                      flexShrink: 0,
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleOpenFullscreen(record);
-                    }}
-                  />
-                </Tooltip>
-              </>
-            )}
+          {(() => {
+            const hasResult = (record as any).has_result ?? record.result;
+            const canViewResults =
+              record.processing_status === "completed" && hasResult;
+            // Also openable while processing (or completed-empty / failed) so the
+            // live timeline is reachable before any result exists.
+            const canViewProgress =
+              !canViewResults &&
+              (record.processing_status === "processing" ||
+                record.extraction_status === "processing" ||
+                record.processing_status === "completed" ||
+                record.processing_status === "failed");
+            if (!canViewResults && !canViewProgress) return null;
+            return (
+              <Tooltip title={canViewResults ? "View results" : "View progress"}>
+                <FullscreenOutlined
+                  style={{ cursor: "pointer", color: "#1890ff", flexShrink: 0 }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleOpenFullscreen(record);
+                  }}
+                />
+              </Tooltip>
+            );
+          })()}
           <Tooltip title={copiedFileId === id ? "Copied!" : "Copy file ID"}>
             {copiedFileId === id ? (
               <CheckCircleOutlined
@@ -1674,7 +1685,7 @@ const FileTable: React.FC<FileTableProps> = ({
     {
       title: "Status",
       key: "processing_status",
-      width: 100,
+      width: 150,
       filters: [
         { text: "Pending", value: "pending" },
         { text: "Processing", value: "processing" },
@@ -1703,14 +1714,20 @@ const FileTable: React.FC<FileTableProps> = ({
             </div>
           }
         >
-          <div
-            className="flex items-center space-x-0.5"
-            style={{ whiteSpace: "nowrap" }}
+          {/* Live, granular status — driven by processing-timeline events,
+              falling back to coarse row status. Click opens the full timeline. */}
+          <span
+            className="cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleOpenFullscreen(record);
+            }}
           >
-            {getUploadStatusIcon(record.upload_status)}
-            {getStatusIcon(record.extraction_status)}
-            {getStatusIcon(record.processing_status)}
-          </div>
+            <ProcessingStatusChip
+              file={record}
+              event={processingEvents?.[record.id]}
+            />
+          </span>
         </Tooltip>
       ),
     },

--- a/src/components/file/FileProcessingPanel.tsx
+++ b/src/components/file/FileProcessingPanel.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Descriptions, Tag, Typography } from "antd";
 import type { JobFile } from "@/lib/api";
 import { buildFileProcessingSummary } from "@/lib/fileProcessingMeta";
+import ProcessingTimeline from "./ProcessingTimeline";
 
 const { Text } = Typography;
 
@@ -24,6 +25,15 @@ export default function FileProcessingPanel({ file }: FileProcessingPanelProps) 
 
   return (
     <div className="p-4 space-y-4 overflow-auto h-full">
+      <div>
+        <Text className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+          Live progress
+        </Text>
+        <div className="mt-2">
+          <ProcessingTimeline fileId={file.id} jobId={file.job_id ?? undefined} />
+        </div>
+      </div>
+
       <div>
         <Text className="text-xs font-medium text-gray-500 uppercase tracking-wide">
           Pipeline

--- a/src/components/file/FileViewerRightPane.tsx
+++ b/src/components/file/FileViewerRightPane.tsx
@@ -74,7 +74,11 @@ export default function FileViewerRightPane({
   onUpdate,
   onSectionsUpdated,
 }: FileViewerRightPaneProps) {
-  const [activeTab, setActiveTab] = useState<RightPaneTab>("results");
+  // Land on the Processing tab when there's no result yet (file opened mid-run),
+  // so the live timeline is what the user sees first; otherwise show Results.
+  const [activeTab, setActiveTab] = useState<RightPaneTab>(() =>
+    file.processing_status === "completed" && file.result ? "results" : "processing",
+  );
   const hasRouting = Boolean(file.detected_sections);
   const sectionCount = file.detected_sections?.sections?.length ?? 0;
   const routingBadge =

--- a/src/components/file/ProcessingStatusChip.tsx
+++ b/src/components/file/ProcessingStatusChip.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React from "react";
+import { Loader2, CheckCircle2, XCircle, CircleSlash, Clock } from "lucide-react";
+import type { JobFile, ProcessingEvent } from "@/lib/api";
+
+/**
+ * Compact, always-visible live status for a file row. Prefers the latest
+ * processing event (granular: "Classifying…", "AI 4/7") and falls back to the
+ * row's coarse extraction/processing status when no live event exists yet.
+ */
+
+type Tone = "blue" | "green" | "red" | "amber" | "gray";
+
+const TONE: Record<Tone, string> = {
+  blue: "bg-blue-50 text-blue-700 border-blue-200",
+  green: "bg-green-50 text-green-700 border-green-200",
+  red: "bg-red-50 text-red-700 border-red-200",
+  amber: "bg-amber-50 text-amber-800 border-amber-200",
+  gray: "bg-gray-50 text-gray-500 border-gray-200",
+};
+
+const PHASE_VERB: Record<string, string> = {
+  classifying: "Classifying…",
+  extracting: "Extracting…",
+  ai_extraction: "Extracting data",
+  post_processing: "Finalizing…",
+};
+
+function derive(
+  file: JobFile,
+  event?: ProcessingEvent,
+): { tone: Tone; label: string; spin?: boolean; icon?: "check" | "x" | "slash" | "clock"; current?: number; total?: number } {
+  // Live event wins (most granular), unless it's terminal — then fall through
+  // to the row status so the chip matches the persisted final state.
+  if (event && !["done", "failed", "skipped"].includes(event.phase)) {
+    const total = event.progress?.total ?? event.progress_total ?? undefined;
+    const current = event.progress?.current ?? event.progress_current ?? undefined;
+    if (event.phase === "ai_extraction" && total) {
+      return { tone: "blue", label: "AI", spin: false, current, total };
+    }
+    return {
+      tone: event.level === "warning" ? "amber" : "blue",
+      label: PHASE_VERB[event.phase] ?? "Processing…",
+      spin: true,
+    };
+  }
+
+  // Fallbacks from coarse row status.
+  const ps = file.processing_status;
+  const es = file.extraction_status;
+  const skipped =
+    (file.processing_metadata as Record<string, unknown> | undefined)?.skipped_reason;
+
+  if (ps === "completed") {
+    if (skipped || !((file as any).has_result ?? file.result)) {
+      return { tone: "amber", label: "No content", icon: "slash" };
+    }
+    return { tone: "green", label: "Completed", icon: "check" };
+  }
+  if (ps === "failed" || es === "failed") {
+    return { tone: "red", label: "Failed", icon: "x" };
+  }
+  if (ps === "processing") {
+    return { tone: "blue", label: "Processing…", spin: true };
+  }
+  if (es === "processing") {
+    return { tone: "blue", label: "Extracting…", spin: true };
+  }
+  return { tone: "gray", label: "Queued", icon: "clock" };
+}
+
+export default function ProcessingStatusChip({
+  file,
+  event,
+}: {
+  file: JobFile;
+  event?: ProcessingEvent;
+}) {
+  const d = derive(file, event);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] font-medium whitespace-nowrap ${TONE[d.tone]}`}
+      title={event?.message || d.label}
+    >
+      {d.spin && <Loader2 className="w-3 h-3 animate-spin" />}
+      {d.icon === "check" && <CheckCircle2 className="w-3 h-3" />}
+      {d.icon === "x" && <XCircle className="w-3 h-3" />}
+      {d.icon === "slash" && <CircleSlash className="w-3 h-3" />}
+      {d.icon === "clock" && <Clock className="w-3 h-3" />}
+      <span>{d.label}</span>
+      {d.total != null && (
+        <>
+          <span className="tabular-nums">
+            {d.current ?? 0}/{d.total}
+          </span>
+          <span className="h-1 w-8 rounded-full bg-blue-100 overflow-hidden">
+            <span
+              className="block h-full bg-blue-500"
+              style={{ width: `${Math.min(100, ((d.current ?? 0) / d.total) * 100)}%` }}
+            />
+          </span>
+        </>
+      )}
+    </span>
+  );
+}

--- a/src/components/file/ProcessingTimeline.tsx
+++ b/src/components/file/ProcessingTimeline.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  CircleSlash,
+  ChevronDown,
+} from "lucide-react";
+import { apiClient, type ProcessingEvent } from "@/lib/api";
+import { useSocket } from "@/hooks/useSocket";
+
+// ── Normalized event (reconciles REST vs socket payload shapes) ──
+type Evt = {
+  seq: number;
+  phase: ProcessingEvent["phase"];
+  status: ProcessingEvent["status"];
+  level: NonNullable<ProcessingEvent["level"]>;
+  message: string;
+  current?: number;
+  total?: number;
+  ts: number;
+};
+
+function normalize(raw: ProcessingEvent, fallbackSeq: number): Evt {
+  return {
+    seq: typeof raw.seq === "number" ? raw.seq : fallbackSeq,
+    phase: raw.phase,
+    status: raw.status,
+    level: (raw.level ?? "info") as Evt["level"],
+    message: raw.message ?? "",
+    current: raw.progress?.current ?? raw.progress_current ?? undefined,
+    total: raw.progress?.total ?? raw.progress_total ?? undefined,
+    ts: raw.created_at ? new Date(raw.created_at).getTime() : Date.now(),
+  };
+}
+
+const PHASE_LABEL: Record<string, string> = {
+  queued: "Queued",
+  classifying: "Classifying pages",
+  extracting: "Extracting text",
+  ai_extraction: "Extracting structured data",
+  post_processing: "Finalizing",
+};
+
+const TERMINAL = new Set(["done", "failed", "skipped"]);
+const PHASE_ORDER = [
+  "queued",
+  "classifying",
+  "extracting",
+  "ai_extraction",
+  "post_processing",
+];
+
+function fmtDuration(ms: number): string {
+  if (ms < 0) ms = 0;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+export default function ProcessingTimeline({
+  fileId,
+  jobId,
+}: {
+  fileId: string;
+  jobId?: string;
+}) {
+  const [events, setEvents] = useState<Evt[]>([]);
+  const [showActivity, setShowActivity] = useState(false);
+  const [now, setNow] = useState(Date.now());
+  const seqRef = useRef(-1);
+
+  // Hydrate from the persisted timeline.
+  useEffect(() => {
+    let cancelled = false;
+    if (!fileId) return;
+    apiClient
+      .getProcessingEvents(fileId)
+      .then((res) => {
+        if (cancelled || res.status !== "success" || !res.events) return;
+        setEvents(
+          (res.events as ProcessingEvent[]).map((e, i) => normalize(e, i)),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [fileId]);
+
+  // Live updates — append events for this file.
+  useSocket(jobId, {
+    onFileProcessingEvent: (data: ProcessingEvent) => {
+      const evtFileId = (data as any).fileId ?? (data as any).file_id;
+      if (evtFileId !== fileId) return;
+      setEvents((prev) => {
+        const e = normalize(data, (prev[prev.length - 1]?.seq ?? -1) + 1);
+        // de-dupe by seq
+        if (prev.some((p) => p.seq === e.seq)) return prev;
+        return [...prev, e].sort((a, b) => a.seq - b.seq);
+      });
+    },
+  });
+
+  const last = events[events.length - 1];
+  const isTerminal = last ? TERMINAL.has(last.phase) : false;
+
+  // Tick while the run is in flight so elapsed/ETA update live.
+  useEffect(() => {
+    if (isTerminal || events.length === 0) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [isTerminal, events.length]);
+
+  const steps = useMemo(() => {
+    const present = [
+      ...new Set(events.filter((e) => !TERMINAL.has(e.phase)).map((e) => e.phase)),
+    ].sort((a, b) => PHASE_ORDER.indexOf(a) - PHASE_ORDER.indexOf(b));
+
+    return present.map((phase) => {
+      const evs = events.filter((e) => e.phase === phase);
+      const latest = evs[evs.length - 1];
+      const startTs = evs[0]?.ts ?? latest.ts;
+
+      let state: "done" | "active" | "failed";
+      if (evs.some((e) => e.level === "error" || e.status === "failed")) {
+        state = "failed";
+      } else if (!isTerminal && last?.phase === phase && latest.status === "active") {
+        state = "active";
+      } else {
+        state = "done";
+      }
+
+      // ETA for determinate, in-flight phases.
+      let eta: number | null = null;
+      if (state === "active" && latest.current && latest.total && latest.current > 0) {
+        const elapsed = now - startTs;
+        const per = elapsed / latest.current;
+        eta = Math.max(0, per * (latest.total - latest.current));
+      }
+
+      const endTs = state === "active" ? now : latest.ts;
+      return { phase, latest, state, startTs, durationMs: endTs - startTs, eta };
+    });
+  }, [events, isTerminal, last?.phase, now]);
+
+  // Inline warnings (e.g. "stopped extracting early") worth surfacing prominently.
+  const warnings = useMemo(
+    () => events.filter((e) => e.level === "warning"),
+    [events],
+  );
+
+  if (events.length === 0) {
+    return (
+      <div className="text-xs text-gray-400 italic px-1 py-2">
+        No processing activity recorded yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Stepper */}
+      <ol className="space-y-2.5">
+        {steps.map(({ phase, latest, state, durationMs, eta }) => (
+          <li key={phase} className="flex items-start gap-2.5">
+            <span className="mt-0.5 flex-shrink-0">
+              {state === "active" && (
+                <Loader2 className="w-4 h-4 text-blue-500 animate-spin" />
+              )}
+              {state === "done" && (
+                <CheckCircle2 className="w-4 h-4 text-green-500" />
+              )}
+              {state === "failed" && (
+                <XCircle className="w-4 h-4 text-red-500" />
+              )}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline justify-between gap-2">
+                <span
+                  className={`text-sm font-medium ${
+                    state === "failed" ? "text-red-700" : "text-gray-800"
+                  }`}
+                >
+                  {PHASE_LABEL[phase] ?? phase}
+                </span>
+                <span className="text-[11px] text-gray-400 tabular-nums whitespace-nowrap">
+                  {state === "active" && eta != null
+                    ? `~${fmtDuration(eta)} left`
+                    : fmtDuration(durationMs)}
+                </span>
+              </div>
+              {latest.message && (
+                <p
+                  className={`text-xs mt-0.5 ${
+                    latest.level === "warning"
+                      ? "text-amber-600"
+                      : "text-gray-500"
+                  }`}
+                >
+                  {latest.message}
+                </p>
+              )}
+              {/* Determinate progress bar */}
+              {latest.total && latest.total > 0 && (
+                <div className="mt-1.5 flex items-center gap-2">
+                  <div className="h-1.5 flex-1 rounded-full bg-gray-100 overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all duration-300 ${
+                        state === "failed" ? "bg-red-400" : "bg-blue-500"
+                      }`}
+                      style={{
+                        width: `${Math.min(100, ((latest.current ?? 0) / latest.total) * 100)}%`,
+                      }}
+                    />
+                  </div>
+                  <span className="text-[11px] text-gray-400 tabular-nums">
+                    {latest.current ?? 0}/{latest.total}
+                  </span>
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      {/* Terminal banner */}
+      {last && TERMINAL.has(last.phase) && (
+        <div
+          className={`flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm ${
+            last.phase === "failed"
+              ? "bg-red-50 text-red-700"
+              : last.phase === "skipped"
+                ? "bg-amber-50 text-amber-800"
+                : "bg-green-50 text-green-700"
+          }`}
+        >
+          {last.phase === "failed" ? (
+            <XCircle className="w-4 h-4" />
+          ) : last.phase === "skipped" ? (
+            <CircleSlash className="w-4 h-4" />
+          ) : (
+            <CheckCircle2 className="w-4 h-4" />
+          )}
+          <span className="font-medium">{last.message}</span>
+        </div>
+      )}
+
+      {/* Prominent warnings */}
+      {warnings.length > 0 && !showActivity && (
+        <div className="space-y-1">
+          {warnings.map((w) => (
+            <div
+              key={w.seq}
+              className="flex items-start gap-1.5 text-xs text-amber-700"
+            >
+              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+              <span>{w.message}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Collapsible activity log */}
+      <div>
+        <button
+          onClick={() => setShowActivity((v) => !v)}
+          className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-gray-600"
+        >
+          <ChevronDown
+            className={`w-3 h-3 transition-transform ${showActivity ? "rotate-180" : ""}`}
+          />
+          {showActivity ? "Hide activity" : `Activity log (${events.length})`}
+        </button>
+        {showActivity && (
+          <div className="mt-1.5 max-h-48 overflow-y-auto rounded border border-gray-100 bg-gray-50 p-2 space-y-0.5 font-mono text-[11px]">
+            {events.map((e) => (
+              <div
+                key={e.seq}
+                className={`flex gap-2 ${
+                  e.level === "error"
+                    ? "text-red-600"
+                    : e.level === "warning"
+                      ? "text-amber-600"
+                      : "text-gray-600"
+                }`}
+              >
+                <span className="text-gray-300 tabular-nums flex-shrink-0">
+                  {new Date(e.ts).toLocaleTimeString()}
+                </span>
+                <span className="text-gray-400 flex-shrink-0">[{e.phase}]</span>
+                <span className="min-w-0">{e.message}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -5,6 +5,7 @@ interface SocketEventHandlers {
     onJobStatusUpdate?: (data: any) => void;
     onFileStatusUpdate?: (data: any) => void;
     onPreviewUpdated?: (data: any) => void;
+    onFileProcessingEvent?: (data: any) => void;
 }
 
 export const useSocket = (jobId?: string, handlers?: SocketEventHandlers) => {
@@ -56,15 +57,21 @@ export const useSocket = (jobId?: string, handlers?: SocketEventHandlers) => {
             handlersRef.current?.onPreviewUpdated?.(data);
         };
 
+        const handleFileProcessingEvent = (data: any) => {
+            handlersRef.current?.onFileProcessingEvent?.(data);
+        };
+
         // Remove old listeners first to avoid duplicates
         newSocket.off('job-status-update');
         newSocket.off('file-status-update');
         newSocket.off('preview-updated');
+        newSocket.off('file-processing-event');
 
         // Register event handlers
         newSocket.on('job-status-update', handleJobStatusUpdate);
         newSocket.on('file-status-update', handleFileStatusUpdate);
         newSocket.on('preview-updated', handlePreviewUpdated);
+        newSocket.on('file-processing-event', handleFileProcessingEvent);
         
         console.log('📡 Registered all Socket.IO event handlers');
 
@@ -79,6 +86,7 @@ export const useSocket = (jobId?: string, handlers?: SocketEventHandlers) => {
             newSocket.off('job-status-update');
             newSocket.off('file-status-update');
             newSocket.off('preview-updated');
+            newSocket.off('file-processing-event');
             newSocket.disconnect();
         };
     }, [jobId]);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -355,6 +355,32 @@ export interface QAFinding {
     updated_at: string;
 }
 
+// ── Processing timeline (curated, frontend-facing progress events) ──
+export type ProcessingPhase =
+    | 'queued' | 'classifying' | 'extracting' | 'ai_extraction'
+    | 'post_processing' | 'done' | 'failed' | 'skipped';
+export type ProcessingEventStatus = 'active' | 'done' | 'failed' | 'info';
+export type ProcessingEventLevel = 'info' | 'warning' | 'error';
+
+export interface ProcessingEvent {
+    id?: string;
+    seq?: number;
+    file_id?: string;
+    fileId?: string; // socket payload uses camelCase
+    job_id?: string | null;
+    jobId?: string | null;
+    phase: ProcessingPhase;
+    step?: string | null;
+    status: ProcessingEventStatus;
+    progress_current?: number | null;
+    progress_total?: number | null;
+    progress?: { current: number; total: number }; // socket payload shape
+    message?: string | null;
+    level?: ProcessingEventLevel;
+    data?: Record<string, unknown> | null;
+    created_at?: string;
+}
+
 // Per-section extraction (Phase 1, item #3 — v2 envelope).
 //
 // When the visual classifier is on AND it produces ≥1 section with extractable
@@ -1547,6 +1573,13 @@ class ApiClient {
         fileId: string,
     ): Promise<ApiResponse<{ findings: Record<string, QAFinding[]> }>> {
         return this.request(`/files/${encodeURIComponent(fileId)}/qa-findings`);
+    }
+
+    /** Get the curated processing timeline for a file (for hydration). */
+    async getProcessingEvents(
+        fileId: string,
+    ): Promise<ApiResponse<{ events: ProcessingEvent[] }>> {
+        return this.request(`/files/${encodeURIComponent(fileId)}/processing-events`);
     }
 
     /** Update a finding's status (accepted or dismissed). */


### PR DESCRIPTION
See processing while it runs — not just after a result exists (the old gap: the timeline was only reachable once "View Result" appeared).

**Stacked on `feat/vlm-qa`** — retarget to `main` once that merges.

## What
- **ProcessingTimeline** (Processing tab): stepper + progress bar + live ETA + activity log; hydrates via `GET /processing-events`, updates over the socket.
- **ProcessingStatusChip**: compact live status in every table row (Classifying… / Extracting data 4/7 / Completed / Failed / No content / Queued).
- Files are now **openable during processing** (open icon + chip); the viewer defaults to the **Processing tab** when there's no result yet.
- One shared socket (reuses the page's existing connection) → latest-event-per-file map → table chips.

## Pairs with
text-to-structured-data `feat/processing-timeline` (backend + the `file_processing_events` migration must run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)