### PR TITLE
feat: field-description tooltips in result viewer

### DIFF
--- a/src/components/json/JsonViewer.tsx
+++ b/src/components/json/JsonViewer.tsx
@@ -26,6 +26,8 @@ const READONLY_TOOLBAR: ToolbarItem[] = ["mode", "search", "copy", "download"];
 export interface JsonViewerProps extends JsonViewerCommonProps {
   /** Internal: when true, toolbar gets save/cancel by default. */
   withSaveCancel?: boolean;
+  /** dot.path -> field description; shows a hover tooltip on keys (tree mode). */
+  descriptions?: Record<string, string>;
 }
 
 function deriveMode(opts: {
@@ -97,6 +99,7 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
     className,
     bodyClassName,
     withSaveCancel,
+    descriptions,
   } = props;
 
   const editor = useJsonEditor({
@@ -326,6 +329,7 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
                     value={editor.value}
                     theme={themeMode}
                     emptyText={emptyText}
+                    descriptions={descriptions}
                   />
                 )}
               </>

--- a/src/components/json/core/JsonTreeView.tsx
+++ b/src/components/json/core/JsonTreeView.tsx
@@ -2,13 +2,17 @@
 
 import React, { useMemo } from "react";
 import JsonView from "@uiw/react-json-view";
+import { Tooltip } from "antd";
 import type { JsonValue } from "../types";
+import { descriptionForPath } from "@/lib/schemaDescriptions";
 
 export interface JsonTreeViewProps {
   value: JsonValue;
   theme?: "light" | "dark";
   collapsed?: number | boolean;
   emptyText?: React.ReactNode;
+  /** dot.path -> field description; renders a hover tooltip on matching keys. */
+  descriptions?: Record<string, string>;
 }
 
 const JsonTreeView: React.FC<JsonTreeViewProps> = ({
@@ -16,7 +20,9 @@ const JsonTreeView: React.FC<JsonTreeViewProps> = ({
   theme = "light",
   collapsed = 2,
   emptyText,
+  descriptions,
 }) => {
+  const hasDescriptions = !!descriptions && Object.keys(descriptions).length > 0;
   const isObjectLike = useMemo(() => {
     return value !== undefined && value !== null && typeof value === "object";
   }, [value]);
@@ -60,7 +66,39 @@ const JsonTreeView: React.FC<JsonTreeViewProps> = ({
               >)
             : {}),
         }}
-      />
+      >
+        {hasDescriptions && (
+          <JsonView.KeyName
+            render={(props, { keyName, keys }) => {
+              const { children, ...rest } = props as React.HTMLAttributes<HTMLSpanElement> & {
+                children?: React.ReactNode;
+              };
+              // `keys` is the full path INCLUDING this node's own key. Array
+              // element indices come through as numeric keys — they're not
+              // schema fields, so skip the tooltip on them.
+              const isIndex = typeof keyName === "number";
+              const fullPath = ((keys as Array<string | number>) ??
+                (keyName != null ? [keyName as string | number] : [])) as Array<string | number>;
+              const desc = isIndex ? undefined : descriptionForPath(fullPath, descriptions!);
+              if (!desc) return <span {...rest}>{children}</span>;
+              return (
+                <Tooltip title={desc} mouseEnterDelay={0.3} placement="top">
+                  <span
+                    {...rest}
+                    style={{
+                      ...(rest.style || {}),
+                      borderBottom: "1px dotted currentColor",
+                      cursor: "help",
+                    }}
+                  >
+                    {children}
+                  </span>
+                </Tooltip>
+              );
+            }}
+          />
+        )}
+      </JsonView>
     </div>
   );
 };

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { jsonToCsv } from "@/lib/csvExport";
+import { buildFieldDescriptionMap } from "@/lib/schemaDescriptions";
 import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
 import { App, Button, Input, Popconfirm, Select, Typography } from "antd";
 import { JsonViewer } from "@/components/json";
@@ -540,6 +541,31 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
     : null;
 
   const [verifyLoading, setVerifyLoading] = useState(false);
+
+  // ── Field descriptions (hover hints in the JSON tree) ──────────────
+  // Fetch the active schema for the selected section's slug, flatten it to a
+  // path→description map, cache per slug. Falls back gracefully when there's no
+  // slug (v1) or the schema can't be loaded.
+  const schemaDescCacheRef = React.useRef<Record<string, Record<string, string>>>({});
+  const [fieldDescriptions, setFieldDescriptions] = useState<Record<string, string>>({});
+  const descSlug = selectedSection?.slug ?? null;
+  useEffect(() => {
+    if (!descSlug) { setFieldDescriptions({}); return; }
+    const cached = schemaDescCacheRef.current[descSlug];
+    if (cached) { setFieldDescriptions(cached); return; }
+    let cancelled = false;
+    apiClient.getDocumentTypeSchema(descSlug).then((res) => {
+      if (cancelled) return;
+      if (res.status === "success" && res.json_schema) {
+        const map = buildFieldDescriptionMap(res.json_schema);
+        schemaDescCacheRef.current[descSlug] = map;
+        setFieldDescriptions(map);
+      } else {
+        setFieldDescriptions({});
+      }
+    }).catch(() => { if (!cancelled) setFieldDescriptions({}); });
+    return () => { cancelled = true; };
+  }, [descSlug]);
 
   const handleVerify = useCallback(
     async (status: SectionVerificationStatus) => {
@@ -1100,6 +1126,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
             <div className="flex-1 min-h-0 flex flex-col">
               <JsonViewer
                 text={editableJson}
+                descriptions={fieldDescriptions}
                 onChange={({ text, isValid, error }) => {
                   setEditableJson(text);
                   setJsonError(isValid ? null : (error ?? "Invalid JSON"));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -880,6 +880,14 @@ class ApiClient {
         return this.request(`/document-types${qs ? `?${qs}` : ''}`);
     }
 
+    /** Active JSON schema for a document type (read-only) — powers field
+     *  descriptions in the result viewer. */
+    async getDocumentTypeSchema(
+        slug: string,
+    ): Promise<ApiResponse<{ slug: string; version: number; json_schema: Record<string, unknown> }>> {
+        return this.request(`/document-types/${encodeURIComponent(slug)}/schema`);
+    }
+
     // ── Schema registry admin (admin JWT only) ───────────────────────────
     async registryGetDocumentTypeDetail(
         slug: string

--- a/src/lib/schemaDescriptions.ts
+++ b/src/lib/schemaDescriptions.ts
@@ -1,0 +1,66 @@
+/**
+ * Flatten a JSON Schema into a `dot.path -> description` map for the result
+ * viewer's field tooltips. Array indices are NOT part of the path — array item
+ * fields are keyed by the array name + field (e.g. `spt_intervals.n_value`),
+ * matching what you get after stripping `[i]` from a runtime path.
+ */
+
+type JsonSchemaNode = {
+  description?: string;
+  type?: string | string[];
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode;
+  [k: string]: unknown;
+};
+
+function isObj(v: unknown): v is JsonSchemaNode {
+  return !!v && typeof v === "object";
+}
+
+export function buildFieldDescriptionMap(
+  jsonSchema: unknown,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const root = isObj(jsonSchema) ? jsonSchema : null;
+  if (!root?.properties) return out;
+
+  const walk = (props: Record<string, JsonSchemaNode>, prefix: string) => {
+    for (const [key, def] of Object.entries(props)) {
+      if (!isObj(def)) continue;
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (typeof def.description === "string" && def.description.trim()) {
+        out[path] = def.description.trim();
+      }
+      // Nested object
+      if (def.properties) {
+        walk(def.properties, path);
+      }
+      // Array of objects → item fields keyed under the array name (no index)
+      if (def.items?.properties) {
+        walk(def.items.properties, path);
+      }
+    }
+  };
+
+  walk(root.properties, "");
+  return out;
+}
+
+/**
+ * Resolve a runtime node path (which may contain numeric array indices) to a
+ * schema description. Strips numeric segments before lookup.
+ *
+ * @param path  array of keys/indices, e.g. ["spt_intervals", 2, "n_value"]
+ */
+export function descriptionForPath(
+  path: Array<string | number>,
+  map: Record<string, string>,
+): string | undefined {
+  if (!path?.length) return undefined;
+  const normalized = path
+    .filter((seg) => typeof seg === "string" || !Number.isInteger(seg))
+    .map((seg) => String(seg))
+    .filter((seg) => seg !== "" && !/^\d+$/.test(seg))
+    .join(".");
+  return map[normalized];
+}


### PR DESCRIPTION
Hover a field key in the Results (tree) view → see its schema description.
Example: `spt_intervals.n_value` → *"ASTM D1586 N = blows_2nd_6in + blows_3rd_6in."*

## How
- `schemaDescriptions.ts` — flattens a JSON schema to `dot.path → description` (handles nested objects + array-item fields), with a resolver that strips `[i]` indices.
- `getDocumentTypeSchema(slug)` → the new read-only `GET /document-types/:slug/schema` (paired backend PR #31 on text-to-structured-data).
- `JsonTreeView` — custom `@uiw/react-json-view` `KeyName` renderer wraps described keys in a tooltip (dotted underline + help cursor); array indices get no tooltip.
- `JsonViewer` threads a `descriptions` prop; `TabbedDataViewer` fetches the section's slug schema (cached) and builds the map.

## Notes
- Tree mode only (code/raw is a plain editor). v2 uses the section's slug; v1 files show no hints (extendable later).
- Requires the backend endpoint (PR #31) deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)