### PR TITLE
Fix file details drawer hidden behind result modal

### DIFF
--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -2700,6 +2700,7 @@ const FileTable: React.FC<FileTableProps> = ({
         file={selectedFileForDetails}
         open={fileDetailsDrawerVisible}
         onClose={handleCloseFileDetails}
+        zIndex={fullscreenModalOpen ? 1100 : undefined}
       />
     </div>
   );

--- a/src/components/file/FileDetailsDrawer.tsx
+++ b/src/components/file/FileDetailsDrawer.tsx
@@ -30,6 +30,8 @@ interface FileDetailsDrawerProps {
   file: JobFile | null;
   open: boolean;
   onClose: () => void;
+  /** Raise above stacked modals (e.g. fullscreen result viewer). */
+  zIndex?: number;
 }
 
 const computePageCount = (file?: JobFile | null): number | null => {
@@ -114,6 +116,7 @@ const FileDetailsDrawer: React.FC<FileDetailsDrawerProps> = ({
   file,
   open,
   onClose,
+  zIndex,
 }) => {
   const selectedFilePageCount = computePageCount(file);
 
@@ -134,6 +137,7 @@ const FileDetailsDrawer: React.FC<FileDetailsDrawerProps> = ({
       onClose={onClose}
       open={open}
       width={600}
+      zIndex={zIndex}
     >
       {file && (
         <div className="space-y-6">


### PR DESCRIPTION
## Summary
- Add optional `zIndex` prop to `FileDetailsDrawer`
- When the fullscreen result modal is open, pass `zIndex={1100}` so the drawer stacks above the modal (Ant Design default `1000`)

## Test plan
- [x] Open a file in the fullscreen result modal
- [x] Click the file details icon
- [x] Confirm the file details drawer slides in on top of the modal (visible without closing the modal)
- [x] Close the drawer, then close the modal — no regressions
- [x] Open file details from the table row menu (modal closed) — drawer still works as before


Made with [Cursor](https://cursor.com)