### PR TITLE
fix: lean save-and-reextract payload

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1051,11 +1051,14 @@ class ApiClient {
         fileId: string,
         detectedSections: DetectedSections,
     ): Promise<ApiResponse<{ detected_sections?: DetectedSections; sectionResults?: unknown[] }>> {
+        // Send only the edited `sections` array — the server preserves all other
+        // classifier metadata (pages, page_summaries, …). This keeps the body
+        // small (avoids PayloadTooLargeError on large files).
         return this.request(
             `/files/${encodeURIComponent(fileId)}/sections/save-and-reextract`,
             {
                 method: 'POST',
-                body: JSON.stringify({ detected_sections: detectedSections }),
+                body: JSON.stringify({ sections: detectedSections.sections }),
             },
         );
     }


### PR DESCRIPTION
Client side of the `PayloadTooLargeError` fix on "Save & re-extract".

`saveAndReextractSections` now sends **only `{ sections }`** instead of the full `detected_sections` (which also carries `pages`, `page_summaries`, `grouper`, `record_inventory` — none of it client-edited). The server merges the sections into the stored metadata.

**Payload on a 78-section file: 118KB → 40KB.** Requires the backend PR (text-to-structured-data #32) which accepts `{ sections }` and merges server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)