### PR TITLE
feat: apply QA finding's expected value into the result JSON

### DIFF
--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -7,6 +7,12 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { jsonToCsv } from "@/lib/csvExport";
 import { buildFieldDescriptionMap } from "@/lib/schemaDescriptions";
+import {
+  getByPath,
+  setByPath,
+  coerceExpected,
+  APPLYABLE_ISSUE_TYPES,
+} from "@/lib/jsonPath";
 import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
 import { App, Button, Input, Popconfirm, Select, Typography } from "antd";
 import { JsonViewer } from "@/components/json";
@@ -243,9 +249,15 @@ const SEVERITY_CONFIG = {
 function QAFindingsPanel({
   findings,
   onUpdate,
+  onApply,
+  canApply,
 }: {
   findings: import("@/lib/api").QAFinding[];
   onUpdate: (findingId: string, status: 'accepted' | 'dismissed') => Promise<void>;
+  /** Inject this finding's `expected` into the editable JSON (review then Save). */
+  onApply: (finding: import("@/lib/api").QAFinding) => void;
+  /** Only show "Apply" when the JSON is editable (otherwise it can't be saved). */
+  canApply: boolean;
 }) {
   const [updating, setUpdating] = useState<string | null>(null);
   const open = findings.filter(f => f.status === 'open');
@@ -279,6 +291,16 @@ function QAFindingsPanel({
           </div>
           {!isResolved && (
             <div className="flex gap-1 flex-shrink-0">
+              {canApply && APPLYABLE_ISSUE_TYPES.has(f.issue_type) && (
+                <>
+                  <button
+                    onClick={() => onApply(f)}
+                    className="text-xs text-blue-700 font-medium hover:underline"
+                    title={`Set ${f.field_path} = ${f.issue_type === 'extra_value' ? 'null' : (f.expected ?? 'null')}`}
+                  >Apply</button>
+                  <span className="text-gray-300">|</span>
+                </>
+              )}
               <button
                 disabled={updating === f.id}
                 onClick={() => handleAction(f.id, 'accepted')}
@@ -671,6 +693,30 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
       setQaLoading('idle');
     }
   }, [fileId, message]);
+
+  // Inject a finding's "right answer" (expected) into the editable JSON at its
+  // field_path. The user reviews the change in the tree and Saves to persist
+  // (via the existing per-record PATCH). extra_value (hallucination) → set null.
+  const handleApplyFinding = useCallback((finding: import("@/lib/api").QAFinding) => {
+    try {
+      const parsed = JSON.parse(editableJson);
+      const current = getByPath(parsed, finding.field_path);
+      const newValue =
+        finding.issue_type === 'extra_value'
+          ? null
+          : coerceExpected(finding.expected, current);
+      const updated = setByPath(parsed, finding.field_path, newValue);
+      setEditableJson(JSON.stringify(updated, null, 2));
+      setJsonError(null);
+      message.success(
+        `Set ${finding.field_path} = ${newValue === null ? 'null' : JSON.stringify(newValue)} — review and Save to persist`,
+      );
+    } catch (err) {
+      message.error(
+        `Couldn't apply: ${err instanceof Error ? err.message : 'invalid JSON'}`,
+      );
+    }
+  }, [editableJson, message]);
 
   const handleUpdateFinding = useCallback(async (findingId: string, status: 'accepted' | 'dismissed') => {
     if (!fileId || !selectedSection?.sectionResultId) return;
@@ -1177,6 +1223,8 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
             <QAFindingsPanel
               findings={selectedSectionFindings}
               onUpdate={handleUpdateFinding}
+              onApply={handleApplyFinding}
+              canApply={editable}
             />
           )}
 

--- a/src/lib/jsonPath.ts
+++ b/src/lib/jsonPath.ts
@@ -1,0 +1,80 @@
+/**
+ * Tiny dot/bracket JSON path helpers for applying a QA finding's `expected`
+ * value back into a result record. Paths look like
+ * "spt_intervals[0].n_value" or "site_identification.county".
+ */
+
+function parsePath(path: string): Array<string | number> {
+  const out: Array<string | number> = [];
+  path
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean)
+    .forEach((seg) => out.push(/^\d+$/.test(seg) ? Number(seg) : seg));
+  return out;
+}
+
+export function getByPath(obj: unknown, path: string): unknown {
+  let cur: unknown = obj;
+  for (const seg of parsePath(path)) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string | number, unknown>)[seg];
+  }
+  return cur;
+}
+
+/**
+ * Immutably set a value at a dot/bracket path. Intermediate objects/arrays are
+ * created as needed (so a previously-null `missing_value` field can be filled).
+ */
+export function setByPath<T>(obj: T, path: string, value: unknown): T {
+  const segs = parsePath(path);
+  if (segs.length === 0) return obj;
+  const clone: any = structuredClone(obj);
+  let cur: any = clone;
+  for (let i = 0; i < segs.length - 1; i++) {
+    const seg = segs[i];
+    const nextIsIndex = typeof segs[i + 1] === "number";
+    if (cur[seg] == null || typeof cur[seg] !== "object") {
+      cur[seg] = nextIsIndex ? [] : {};
+    }
+    cur = cur[seg];
+  }
+  cur[segs[segs.length - 1]] = value;
+  return clone;
+}
+
+/**
+ * Coerce a finding's `expected` string to the right JS type for the target
+ * field — based on the field's current value, falling back to inferring from
+ * the string. Empty/placeholder → null.
+ */
+export function coerceExpected(
+  expected: string | null,
+  currentValue: unknown,
+): unknown {
+  if (expected == null) return null;
+  const s = String(expected).trim();
+  if (s === "" || /^(null|n\/a|none)$/i.test(s)) return null;
+
+  if (typeof currentValue === "number") {
+    const n = Number(s.replace(/,/g, ""));
+    return Number.isNaN(n) ? s : n;
+  }
+  if (typeof currentValue === "boolean") return /^(true|yes)$/i.test(s);
+
+  if (currentValue == null) {
+    // Infer from the string when there's no existing typed value to match.
+    if (/^-?\d+(\.\d+)?$/.test(s.replace(/,/g, ""))) return Number(s.replace(/,/g, ""));
+    if (/^(true|false)$/i.test(s)) return /^true$/i.test(s);
+  }
+  return s;
+}
+
+/** Issue types whose `expected` maps to a single field value we can inject. */
+export const APPLYABLE_ISSUE_TYPES = new Set([
+  "wrong_value",
+  "missing_value",
+  "extra_value",
+  "formatting",
+]);


### PR DESCRIPTION
One-click inject a QA finding's "right answer" (`expected`) into the result JSON.

## Design (optimal: frontend-only, with review)
**Apply** sets the field at the finding's `field_path` to its `expected` value in the **live editable JSON** — you see it in the tree, then **Save** persists it through the existing per-record `PATCH /files/:id/result/:sectionResultId`. No new endpoint, no duplicated persistence, and a review step before anything is written.

## Behaviour
- **Apply** appears on scalar findings: `wrong_value`, `missing_value`, `extra_value` (→ `null`), `formatting` — and only when the JSON is editable.
- **Type-coerced** to the field's current type: `"7"`→`7`, `"true"`→`true`, `"Null"`/`""`→`null`; infers from the string when the field is currently null.
- **Row-count issues** (`missing_rows`/`extra_rows`/`wrong_count`) get no Apply — there's no single value to inject.
- Apply only **stages** the change; Accept/Dismiss stays separate (apply ≠ resolve).

## Files
- `lib/jsonPath.ts` (new): `getByPath`, `setByPath`, `coerceExpected`, `APPLYABLE_ISSUE_TYPES`.
- `TabbedDataViewer`: `handleApplyFinding` + the panel's Apply button.

## To review
Open a section's Results tab with QA findings → click **Apply** on a finding → the field updates in the tree → **Save**. Verified the path/coerce logic against numeric, boolean, nested-array, and null cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)