### PR TITLE
feat: assign classifier-skipped pages to sections from the routing panel

### DIFF
--- a/src/components/DocumentRoutingPanel.tsx
+++ b/src/components/DocumentRoutingPanel.tsx
@@ -32,6 +32,8 @@ import {
   splitSection,
   mergeSections,
   changeSectionSlug,
+  addPageToSection,
+  createSectionFromPage,
   hasUnsavedChanges,
   getSectionsNeedingExtraction,
 } from "@/lib/routingEdits";
@@ -59,10 +61,12 @@ interface Props {
   onSectionsUpdated?: (next: DetectedSections) => void;
 }
 
-type ActionKind = "change_slug" | "split" | "merge";
+type ActionKind = "change_slug" | "split" | "merge" | "new_section";
 interface ActionState {
   kind: ActionKind;
   sectionIndex: number;
+  // For "new_section": the orphan page the section is created from.
+  pageNumber?: number;
 }
 
 // ─── Per-page thumbnail with intersection-observer-based lazy fetch ────────
@@ -243,6 +247,21 @@ function pagesOutsideAnySection(
   );
 }
 
+// For an orphan page, find the nearest section ending before it (prev) and the
+// nearest section starting after it (next). Sections are in document order.
+function adjacentSectionIndices(
+  pageNumber: number,
+  sections: DetectedSection[]
+): { prevIdx: number; nextIdx: number } {
+  let prevIdx = -1;
+  let nextIdx = -1;
+  for (let i = 0; i < sections.length; i++) {
+    if (sections[i].page_range[1] < pageNumber) prevIdx = i;
+    if (sections[i].page_range[0] > pageNumber && nextIdx === -1) nextIdx = i;
+  }
+  return { prevIdx, nextIdx };
+}
+
 // ─── Main component ───────────────────────────────────────────────────────
 
 export default function DocumentRoutingPanel({
@@ -369,6 +388,40 @@ export default function DocumentRoutingPanel({
     [activeSections],
   );
 
+  const handleAddToSection = useCallback(
+    (pageNumber: number, sectionIndex: number) => {
+      if (!activeSections) return;
+      try {
+        const updated = addPageToSection(activeSections, sectionIndex, pageNumber);
+        setDraft(updated);
+        message.success(`Page ${pageNumber} added to section (unsaved)`);
+      } catch (err: unknown) {
+        message.error(err instanceof Error ? err.message : "Add failed");
+      }
+    },
+    [activeSections],
+  );
+
+  const handleCreateSection = useCallback(() => {
+    if (!activeAction || activeAction.kind !== "new_section") return;
+    if (activeAction.pageNumber == null || !pickedSlug) return;
+    if (!activeSections) return;
+    try {
+      const updated = createSectionFromPage(
+        activeSections,
+        activeAction.pageNumber,
+        pickedSlug,
+      );
+      setDraft(updated);
+      message.success(
+        `Page ${activeAction.pageNumber} → new ${pickedSlug} section (unsaved)`,
+      );
+      closeAction();
+    } catch (err: unknown) {
+      message.error(err instanceof Error ? err.message : "Create failed");
+    }
+  }, [activeAction, pickedSlug, activeSections, closeAction]);
+
   const handleDiscard = useCallback(() => {
     setDraft(null);
     message.info("Changes discarded");
@@ -390,6 +443,14 @@ export default function DocumentRoutingPanel({
             ? `Saved and re-extracted ${count} section${count === 1 ? "" : "s"}`
             : "Saved (no extraction needed)",
         );
+        const noText = res.pages_without_text ?? [];
+        if (noText.length > 0) {
+          message.warning(
+            `No extractable text found for page${noText.length === 1 ? "" : "s"} ${noText.join(", ")} — ` +
+              `the corresponding section${noText.length === 1 ? "" : "s"} may have produced no content.`,
+            8,
+          );
+        }
         if (res.detected_sections) {
           onSectionsUpdated?.(res.detected_sections);
         }
@@ -664,17 +725,116 @@ export default function DocumentRoutingPanel({
                     {orphans.length} page
                     {orphans.length === 1 ? "" : "s"} outside any section
                   </span>
+                  <span className="text-xs text-gray-400">
+                    — assign to extract their content
+                  </span>
                 </div>
               ),
               children: (
                 <div className="flex flex-col gap-2">
-                  {orphans.map((p) => (
-                    <PageRow
-                      key={p.page_number}
-                      fileId={fileId}
-                      d={{ page: p, decision: "outside" }}
-                    />
-                  ))}
+                  {orphans.map((p) => {
+                    const { prevIdx, nextIdx } = adjacentSectionIndices(
+                      p.page_number,
+                      sections,
+                    );
+                    const canPrev =
+                      prevIdx >= 0 &&
+                      sections[prevIdx].page_range[1] + 1 === p.page_number;
+                    const canNext =
+                      nextIdx >= 0 &&
+                      sections[nextIdx].page_range[0] - 1 === p.page_number;
+                    return (
+                      <PageRow
+                        key={p.page_number}
+                        fileId={fileId}
+                        d={{ page: p, decision: "outside" }}
+                        actions={
+                          <div className="flex flex-col gap-1 items-stretch min-w-[190px]">
+                            <span className="text-xs font-medium text-gray-500">
+                              Assign this page
+                            </span>
+                            {canPrev && (
+                              <Popconfirm
+                                title={`Add page ${p.page_number} to the previous section`}
+                                description={
+                                  <span className="text-xs">
+                                    It will be extracted as part of{" "}
+                                    <b>{sections[prevIdx].document_type_slug}</b>{" "}
+                                    (pages {sections[prevIdx].page_range[0]}–
+                                    {sections[prevIdx].page_range[1]}). The
+                                    page&apos;s text is pulled from the original
+                                    PDF when you Save &amp; Re-extract.
+                                  </span>
+                                }
+                                okText="Add page"
+                                cancelText="Cancel"
+                                onConfirm={() =>
+                                  handleAddToSection(p.page_number, prevIdx)
+                                }
+                              >
+                                <Tooltip
+                                  title={`Merge into the preceding ${sections[prevIdx].document_type_slug} section (pages ${sections[prevIdx].page_range[0]}–${sections[prevIdx].page_range[1]})`}
+                                >
+                                  <Button size="small" block>
+                                    ← Add to {sections[prevIdx].document_type_slug}{" "}
+                                    (p{sections[prevIdx].page_range[0]}–
+                                    {sections[prevIdx].page_range[1]})
+                                  </Button>
+                                </Tooltip>
+                              </Popconfirm>
+                            )}
+                            {canNext && (
+                              <Popconfirm
+                                title={`Add page ${p.page_number} to the next section`}
+                                description={
+                                  <span className="text-xs">
+                                    It will be extracted as part of{" "}
+                                    <b>{sections[nextIdx].document_type_slug}</b>{" "}
+                                    (pages {sections[nextIdx].page_range[0]}–
+                                    {sections[nextIdx].page_range[1]}). The
+                                    page&apos;s text is pulled from the original
+                                    PDF when you Save &amp; Re-extract.
+                                  </span>
+                                }
+                                okText="Add page"
+                                cancelText="Cancel"
+                                onConfirm={() =>
+                                  handleAddToSection(p.page_number, nextIdx)
+                                }
+                              >
+                                <Tooltip
+                                  title={`Merge into the following ${sections[nextIdx].document_type_slug} section (pages ${sections[nextIdx].page_range[0]}–${sections[nextIdx].page_range[1]})`}
+                                >
+                                  <Button size="small" block>
+                                    Add to {sections[nextIdx].document_type_slug}{" "}
+                                    (p{sections[nextIdx].page_range[0]}–
+                                    {sections[nextIdx].page_range[1]}) →
+                                  </Button>
+                                </Tooltip>
+                              </Popconfirm>
+                            )}
+                            <Tooltip title="Create a new single-page section for this page with a document type you choose">
+                              <Button
+                                size="small"
+                                type="dashed"
+                                block
+                                onClick={() => {
+                                  setPickedSlug(null);
+                                  setActiveAction({
+                                    kind: "new_section",
+                                    sectionIndex: -1,
+                                    pageNumber: p.page_number,
+                                  });
+                                }}
+                              >
+                                + New section…
+                              </Button>
+                            </Tooltip>
+                          </div>
+                        }
+                      />
+                    );
+                  })}
                 </div>
               ),
             },
@@ -772,6 +932,41 @@ export default function DocumentRoutingPanel({
               />
             );
           })()}
+        </div>
+      </Modal>
+
+      {/* New-section-from-orphan-page modal */}
+      <Modal
+        title={
+          activeAction?.kind === "new_section"
+            ? `New section from page ${activeAction.pageNumber}`
+            : "New section"
+        }
+        open={activeAction?.kind === "new_section"}
+        onCancel={closeAction}
+        onOk={handleCreateSection}
+        okText="Create section"
+        okButtonProps={{ disabled: !pickedSlug }}
+        destroyOnHidden
+      >
+        <div className="space-y-3">
+          <div className="text-xs text-gray-500">
+            Creates a new single-page section for this page. Its text wasn&apos;t
+            extracted at ingest, so on Save it will be extracted from the
+            original PDF, then run through the chosen type&apos;s schema.
+          </div>
+          <Select
+            showSearch
+            value={pickedSlug ?? undefined}
+            onChange={(v) => setPickedSlug(v)}
+            placeholder={slugsLoaded ? "Pick a document type" : "Loading types…"}
+            optionFilterProp="label"
+            className="w-full"
+            options={availableSlugs.map((d) => ({
+              value: d.slug,
+              label: `${d.display_name}  ·  ${d.slug}${d.status !== "active" ? " (deprecated)" : ""}`,
+            }))}
+          />
         </div>
       </Modal>
     </div>
@@ -900,9 +1095,11 @@ function SectionHeader({ section }: { section: DetectedSection }) {
 function PageRow({
   fileId,
   d,
+  actions,
 }: {
   fileId: string;
   d: PageDecision;
+  actions?: React.ReactNode;
 }) {
   const { page, decision, reason, duplicate_of } = d;
   return (
@@ -960,6 +1157,7 @@ function PageRow({
           )}
         </div>
       </div>
+      {actions && <div className="shrink-0">{actions}</div>}
     </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1050,7 +1050,7 @@ class ApiClient {
     async saveAndReextractSections(
         fileId: string,
         detectedSections: DetectedSections,
-    ): Promise<ApiResponse<{ detected_sections?: DetectedSections; sectionResults?: unknown[] }>> {
+    ): Promise<ApiResponse<{ detected_sections?: DetectedSections; sectionResults?: unknown[]; pages_without_text?: number[] }>> {
         // Send only the edited `sections` array — the server preserves all other
         // classifier metadata (pages, page_summaries, …). This keeps the body
         // small (avoids PayloadTooLargeError on large files).

--- a/src/lib/routingEdits.ts
+++ b/src/lib/routingEdits.ts
@@ -197,6 +197,123 @@ export function changeSectionSlug(
   return blob;
 }
 
+const DEFAULT_THRESHOLD = 0.75;
+
+/**
+ * Add a single page (typically one the classifier left "outside any section")
+ * into an existing section, as an extraction page. This is a reviewer override
+ * of the classifier's skip decision, so the page is forced into
+ * `extraction_pages` regardless of its page_purpose. The section's range is
+ * widened to cover the page and it's marked for re-extraction.
+ *
+ * Intended for pages adjacent to the section boundary; the caller (UI) only
+ * offers this when `page === section.end + 1` or `page === section.start - 1`,
+ * which keeps the [start,end] range contiguous and avoids swallowing other
+ * unassigned pages into the section's display range.
+ */
+export function addPageToSection(
+  detectedSections: DetectedSections,
+  index: number,
+  pageNumber: number
+): DetectedSections {
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new Error(`Invalid pageNumber '${pageNumber}' — must be a positive integer`);
+  }
+
+  const blob = cloneBlob(detectedSections);
+  const section = requireSection(blob, index);
+
+  if (section.extraction_pages.includes(pageNumber)) {
+    throw new Error(`Page ${pageNumber} is already in this section`);
+  }
+
+  // Force into extraction (override the classifier's skip), keep sorted.
+  section.extraction_pages = [...section.extraction_pages, pageNumber].sort(
+    (a, b) => a - b
+  );
+  // If it was previously recorded as a skipped page here, drop that record.
+  section.skipped_pages = section.skipped_pages.filter(
+    (s) => s.page_number !== pageNumber
+  );
+
+  const start = Math.min(section.page_range[0], pageNumber);
+  const end = Math.max(section.page_range[1], pageNumber);
+  section.page_range = [start, end];
+  section.page_count = end - start + 1;
+  section.status = "approved";
+  section.section_result_id = null;
+
+  blob.status = deriveFileStatus(blob.sections);
+  return blob;
+}
+
+/**
+ * Create a brand-new single-page section from a page the classifier left
+ * outside any section, with the reviewer-chosen slug. Inserted at the correct
+ * document-order position (by page number) so the section ordering — and the
+ * V2 envelope's positional pairing — stays consistent. Marked for extraction.
+ */
+export function createSectionFromPage(
+  detectedSections: DetectedSections,
+  pageNumber: number,
+  slug: string
+): DetectedSections {
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new Error(`Invalid pageNumber '${pageNumber}' — must be a positive integer`);
+  }
+  if (!slug) {
+    throw new Error("A document type slug is required");
+  }
+
+  const blob = cloneBlob(detectedSections);
+
+  if (
+    Array.isArray(blob.sections) &&
+    blob.sections.some(
+      (s) =>
+        pageNumber >= s.page_range[0] && pageNumber <= s.page_range[1]
+    )
+  ) {
+    throw new Error(`Page ${pageNumber} already belongs to a section`);
+  }
+
+  const page = (blob.pages ?? []).find((p) => p.page_number === pageNumber);
+  const conf = typeof page?.confidence === "number" ? page.confidence : 0;
+  // Inherit threshold from an existing section of the same slug, if any.
+  const sameSlug = (blob.sections ?? []).find(
+    (s) => s.document_type_slug === slug
+  );
+
+  const newSection: DetectedSection = {
+    document_type_slug: slug,
+    page_range: [pageNumber, pageNumber],
+    page_count: 1,
+    extraction_pages: [pageNumber],
+    skipped_pages: [],
+    page_roles: [page?.page_role ?? null],
+    page_purposes: [page?.page_purpose ?? "unknown"],
+    confidence: Number(conf.toFixed(4)),
+    min_page_confidence: Number(conf.toFixed(4)),
+    status: "approved",
+    threshold_used: sameSlug?.threshold_used ?? DEFAULT_THRESHOLD,
+    section_result_id: null,
+  };
+
+  if (!Array.isArray(blob.sections)) blob.sections = [];
+  const insertAt = blob.sections.findIndex(
+    (s) => s.page_range[0] > pageNumber
+  );
+  if (insertAt === -1) blob.sections.push(newSection);
+  else blob.sections.splice(insertAt, 0, newSection);
+
+  // Reflect the reviewer's decision on the page itself, so it no longer reads
+  // as "none"/unassigned in the per-page view.
+  if (page) page.document_type_slug = slug;
+
+  blob.status = deriveFileStatus(blob.sections);
+  return blob;
+}
+
 /**
  * Check if a DetectedSections blob has unsaved changes compared to another.
  * Compares section count, page ranges, slugs, and section_result_ids.


### PR DESCRIPTION
## What
Pages the visual classifier left "outside any section" can now be routed by a reviewer in the Document Routing panel. Each orphan page gets actions to **add it to the adjacent section** or **create a new single-page section** (slug picker). Edits the client-side draft and marks affected/new sections `section_result_id=null`, so the existing **Save & Re-extract** flow handles them.

## UX
- Descriptive button labels: `← Add to <slug> (p..–..)` / `Add to <slug> (p..–..) →` / `+ New section…`, under an "Assign this page" header.
- A `Popconfirm` on each add action spells out exactly what will change (which section, that text is pulled from the original PDF on Save).
- Add-to-section is offered only for the *adjacent* section, keeping page ranges contiguous (consecutive orphans resolve incrementally).
- Surfaces the backend's `pages_without_text` as a warning toast on save.

## Changes
- **routingEdits.ts** — `addPageToSection` (force a skipped page into `extraction_pages`, widen range) and `createSectionFromPage` (new single-page section inserted in document order).
- **DocumentRoutingPanel.tsx** — orphan-page actions, labels + confirms, new-section modal, save-time warning.
- **api.ts** — `pages_without_text` added to the save-and-reextract response type.

## Verification
- `tsc --noEmit` clean for the changed files.
- Pure-function test on the real-file scenario (orphan p57 between sections [56,56] and [58,58]): add-to-prev → range/extraction `[56,57]`; create-new inserts in document order `[[56,56],[57,57],[58,58]]`; immutability + duplicate-guard pass.

## Coupling
Requires the backend PR (text-aware re-extract). Deploy **backend-first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)