### PR TITLE
feat: default CodeMirror light theme and line-wrap toggle in JsonViewer

### DIFF
--- a/src/components/json/JsonViewer.tsx
+++ b/src/components/json/JsonViewer.tsx
@@ -16,12 +16,19 @@ const DEFAULT_TOOLBAR: ToolbarItem[] = [
   "mode",
   "format",
   "minify",
+  "wrap",
   "search",
   "copy",
   "download",
 ];
 
-const READONLY_TOOLBAR: ToolbarItem[] = ["mode", "search", "copy", "download"];
+const READONLY_TOOLBAR: ToolbarItem[] = [
+  "mode",
+  "wrap",
+  "search",
+  "copy",
+  "download",
+];
 
 export interface JsonViewerProps extends JsonViewerCommonProps {
   /** Internal: when true, toolbar gets save/cancel by default. */
@@ -44,22 +51,9 @@ function deriveMode(opts: {
   return "tree";
 }
 
-function useIsDarkAntd(theme: "light" | "dark" | "auto"): "light" | "dark" {
-  // Inspect the AntD theme token at render-time. We do this with a hook that
-  // reads from ConfigProvider's token; for simplicity we use a media query +
-  // explicit override.
-  const [systemDark, setSystemDark] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    setSystemDark(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, []);
-  if (theme === "light") return "light";
-  if (theme === "dark") return "dark";
-  return systemDark ? "dark" : "light";
+/** CodeMirror / @uiw default is light; only use dark when explicitly requested. */
+function resolveEditorTheme(theme: "light" | "dark" | "auto"): "light" | "dark" {
+  return theme === "dark" ? "dark" : "light";
 }
 
 const JsonViewer: React.FC<JsonViewerProps> = (props) => {
@@ -87,13 +81,16 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
     extraActions,
     showStatusBar = true,
     showLineNumbers = true,
+    lineWrap: lineWrapProp,
+    defaultLineWrap = false,
+    onLineWrapChange,
     bordered = true,
     onSave,
     onCancel,
     saveLabel,
     cancelLabel,
     saving,
-    theme = "auto",
+    theme = "light",
     placeholder,
     emptyText,
     className,
@@ -125,6 +122,19 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
     [],
   );
   const [mode, setMode] = useState<JsonMode>(initialMode);
+  const [internalLineWrap, setInternalLineWrap] = useState(defaultLineWrap);
+  const lineWrap = lineWrapProp ?? internalLineWrap;
+  const setLineWrap = useCallback(
+    (wrap: boolean) => {
+      if (lineWrapProp === undefined) setInternalLineWrap(wrap);
+      onLineWrapChange?.(wrap);
+    },
+    [lineWrapProp, onLineWrapChange],
+  );
+
+  useEffect(() => {
+    if (lineWrapProp !== undefined) setInternalLineWrap(lineWrapProp);
+  }, [lineWrapProp]);
 
   useEffect(() => {
     if (modeProp && modeProp !== "auto" && modeProp !== mode) {
@@ -142,7 +152,7 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
   );
 
   const codeRef = useRef<ReactCodeMirrorRef | null>(null);
-  const themeMode = useIsDarkAntd(theme);
+  const themeMode = resolveEditorTheme(theme);
 
   const resolvedToolbarItems = useMemo<ToolbarItem[]>(() => {
     if (toolbar === false) return [];
@@ -296,6 +306,8 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
               onDownload={handleDownload}
               onUpload={handleUpload}
               onSearch={handleSearch}
+              lineWrap={lineWrap}
+              onLineWrapChange={setLineWrap}
               onSave={onSave ? handleSave : undefined}
               onCancel={onCancel}
             />
@@ -313,6 +325,7 @@ const JsonViewer: React.FC<JsonViewerProps> = (props) => {
                 onChange={editor.setText}
                 readOnly={readOnly}
                 theme={themeMode}
+                lineWrap={lineWrap}
                 placeholder={placeholder}
                 editorRef={codeRef}
                 showLineNumbers={showLineNumbers}

--- a/src/components/json/core/JsonCodeEditor.tsx
+++ b/src/components/json/core/JsonCodeEditor.tsx
@@ -9,13 +9,13 @@ import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter, lintGutter } from "@codemirror/lint";
 import { search, openSearchPanel } from "@codemirror/search";
 import { foldGutter } from "@codemirror/language";
-import { getCodeMirrorTheme } from "./theme";
 
 export interface JsonCodeEditorProps {
   value: string;
   onChange?: (value: string) => void;
   readOnly?: boolean;
   theme?: "light" | "dark";
+  lineWrap?: boolean;
   height?: string | number;
   minHeight?: string | number;
   maxHeight?: string | number;
@@ -30,6 +30,7 @@ const JsonCodeEditor: React.FC<JsonCodeEditorProps> = ({
   onChange,
   readOnly,
   theme = "light",
+  lineWrap = false,
   height,
   minHeight,
   maxHeight,
@@ -45,10 +46,9 @@ const JsonCodeEditor: React.FC<JsonCodeEditorProps> = ({
       lintGutter(),
       search({ top: true }),
       foldGutter(),
-      EditorView.lineWrapping,
-      ...getCodeMirrorTheme(theme),
+      ...(lineWrap ? [EditorView.lineWrapping] : []),
     ],
-    [theme],
+    [lineWrap],
   );
 
   const handleChange = useCallback(
@@ -99,11 +99,11 @@ const JsonCodeEditor: React.FC<JsonCodeEditorProps> = ({
           bracketMatching: true,
           closeBrackets: true,
           indentOnInput: true,
-          syntaxHighlighting: false,
+          syntaxHighlighting: true,
           dropCursor: true,
         }}
         placeholder={placeholder}
-        theme="none"
+        theme={theme}
         autoFocus={autoFocus}
         style={{ height: "100%" }}
       />

--- a/src/components/json/core/Toolbar.tsx
+++ b/src/components/json/core/Toolbar.tsx
@@ -14,6 +14,7 @@ import {
   AppstoreOutlined,
   CodeOutlined,
   DiffOutlined,
+  ColumnWidthOutlined,
 } from "@ant-design/icons";
 import type { JsonMode, ToolbarItem } from "../types";
 
@@ -34,6 +35,8 @@ interface ToolbarProps {
   onDownload: () => void;
   onUpload: (file: File) => Promise<void>;
   onSearch?: () => void;
+  lineWrap?: boolean;
+  onLineWrapChange?: (wrap: boolean) => void;
   onSave?: () => void;
   onCancel?: () => void;
   size?: "small" | "middle";
@@ -56,6 +59,8 @@ const Toolbar: React.FC<ToolbarProps> = ({
   onDownload,
   onUpload,
   onSearch,
+  lineWrap = false,
+  onLineWrapChange,
   onSave,
   onCancel,
   size = "small",
@@ -138,6 +143,17 @@ const Toolbar: React.FC<ToolbarProps> = ({
               type="text"
               icon={<SearchOutlined />}
               onClick={onSearch}
+            />
+          </Tooltip>
+        )}
+        {includes("wrap") && mode === "code" && onLineWrapChange && (
+          <Tooltip title={lineWrap ? "Disable line wrap" : "Wrap lines"}>
+            <Button
+              size={size}
+              type={lineWrap ? "primary" : "text"}
+              icon={<ColumnWidthOutlined />}
+              onClick={() => onLineWrapChange(!lineWrap)}
+              aria-pressed={lineWrap}
             />
           </Tooltip>
         )}

--- a/src/components/json/types.ts
+++ b/src/components/json/types.ts
@@ -8,6 +8,7 @@ export type ToolbarItem =
   | "mode"
   | "format"
   | "minify"
+  | "wrap"
   | "copy"
   | "download"
   | "upload"
@@ -65,6 +66,10 @@ export interface JsonViewerCommonProps {
   showSearch?: boolean;
   showStatusBar?: boolean;
   showLineNumbers?: boolean;
+  /** Code mode: wrap long lines (toolbar toggle when uncontrolled). */
+  lineWrap?: boolean;
+  defaultLineWrap?: boolean;
+  onLineWrapChange?: (wrap: boolean) => void;
   bordered?: boolean;
 
   // Save / Cancel hooks
@@ -74,7 +79,7 @@ export interface JsonViewerCommonProps {
   cancelLabel?: string;
   saving?: boolean;
 
-  // Theming
+  // Theming — matches @uiw/react-codemirror default (light). `auto` is treated as light.
   theme?: "light" | "dark" | "auto";
 
   // Misc

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -1513,6 +1513,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
                         "mode",
                         "format",
                         "minify",
+                        "wrap",
                         "search",
                         "copy",
                         "download",
@@ -1520,7 +1521,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
                         "cancel",
                         "save",
                       ]
-                    : ["mode", "search", "copy", "download"]
+                    : ["mode", "wrap", "search", "copy", "download"]
                 }
                 onSave={
                   editable


### PR DESCRIPTION
## Summary
- Default JsonViewer CodeMirror theme to built-in `light` (fixes navy One Dark when OS is in dark mode; `auto` maps to light).
- Add a toolbar line-wrap toggle for code view, defaulting to no wrap.
- Wire wrap into the result viewer toolbar in `TabbedDataViewer`.

## Test plan
- [ ] Open a job result in the JSON viewer (tree + code modes).
- [ ] Confirm code view uses a light editor theme regardless of OS dark mode.
- [ ] Toggle wrap in code view and verify long lines wrap/unwrap.
- [ ] Confirm read-only result view still shows wrap (no format/save controls).


Made with [Cursor](https://cursor.com)