### PR TITLE
Preview: schema-driven RecordView + heroes, collapsible rail, URL state

### DIFF
--- a/src/app/preview/[id]/PreviewRail.tsx
+++ b/src/app/preview/[id]/PreviewRail.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, Layers } from "lucide-react";
+
+export type PreviewView =
+  | { kind: "records"; slug?: string } // slug undefined = all; "untyped" = no-type bucket
+  | { kind: "files" }
+  | { kind: "file"; fileId: string; filename: string };
+
+const TYPE_NAMES: Record<string, string> = {
+  mgs_well_log: "Well Logs",
+  borehole_log: "Boring Logs",
+  aquifer_test: "Aquifer Tests",
+  analytical_results: "Analytical Results",
+  well_coordinate_table: "Well Coordinates",
+  field_sampling_forms: "Field Sampling",
+};
+
+const COLLAPSED_KEY = "previewRailCollapsed";
+
+export function documentTypeLabel(slug: string | null | undefined): string {
+  if (!slug) return "Untyped";
+  return (
+    TYPE_NAMES[slug] ??
+    slug.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}
+
+function RailItem({
+  active,
+  count,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  count?: number;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full flex items-center justify-between gap-2 px-3 py-1.5 rounded-md text-sm text-left transition-colors ${
+        active
+          ? "bg-blue-50 text-blue-700 font-medium"
+          : "text-gray-600 hover:bg-gray-100"
+      }`}
+    >
+      <span className="truncate">{children}</span>
+      {count != null && (
+        <span className="text-xs tabular-nums text-gray-400">{count}</span>
+      )}
+    </button>
+  );
+}
+
+/**
+ * Collapsible left rail for the preview page — replaces document-type tabs.
+ * Shows "All records" + "Files" + one entry per document type (with counts), so
+ * navigation always reveals the full landscape and scales past a few types.
+ * Collapse state persists in localStorage (mirrors the jobs rail).
+ */
+export function PreviewRail({
+  slugs,
+  totalRecords,
+  totalFiles,
+  view,
+  onSelect,
+}: {
+  slugs: Array<{ slug: string | null; count: number }>;
+  totalRecords?: number;
+  totalFiles?: number;
+  view: PreviewView;
+  onSelect: (v: PreviewView) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(COLLAPSED_KEY) === "true") setCollapsed(true);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const toggle = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        localStorage.setItem(COLLAPSED_KEY, String(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+
+  const recordsAllActive = view.kind === "records" && !view.slug;
+  const filesActive = view.kind === "files" || view.kind === "file";
+
+  return (
+    <aside
+      className={`shrink-0 flex flex-col border-r border-gray-200 bg-white overflow-hidden transition-[width] duration-200 ease-out ${
+        collapsed ? "w-12" : "w-56"
+      }`}
+      aria-label="Preview views"
+    >
+      {collapsed ? (
+        <div className="flex flex-col items-center py-3 gap-2">
+          <button
+            type="button"
+            onClick={toggle}
+            className="p-2 rounded-lg hover:bg-gray-100 text-gray-600"
+            title="Expand views"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+          <Layers className="h-4 w-4 text-gray-400" aria-hidden />
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between px-2 py-2 border-b border-gray-100">
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 pl-1">
+              Views
+            </span>
+            <button
+              type="button"
+              onClick={toggle}
+              className="p-1.5 rounded-md hover:bg-gray-100 text-gray-500"
+              title="Collapse views"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="p-3 flex flex-col gap-1 overflow-y-auto">
+            <RailItem
+              active={recordsAllActive}
+              count={totalRecords}
+              onClick={() => onSelect({ kind: "records" })}
+            >
+              All records
+            </RailItem>
+            <RailItem
+              active={filesActive}
+              count={totalFiles}
+              onClick={() => onSelect({ kind: "files" })}
+            >
+              Files
+            </RailItem>
+
+            {slugs.length > 0 && (
+              <div className="mt-3 mb-1 px-3 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+                Data types
+              </div>
+            )}
+            {slugs.map((s) => {
+              const key = s.slug ?? "untyped";
+              return (
+                <RailItem
+                  key={key}
+                  active={view.kind === "records" && view.slug === key}
+                  count={s.count}
+                  onClick={() => onSelect({ kind: "records", slug: key })}
+                >
+                  {documentTypeLabel(s.slug)}
+                </RailItem>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   Spin,
 } from "antd";
 import { RecordView } from "@/components/record/RecordView";
+import { humanizeKey } from "@/components/record/recordSchema";
 import {
   PreviewRail,
   PreviewView,
@@ -141,9 +142,85 @@ interface TableColumn {
 
 interface ArrayPopupData {
   columnKey: string;
-  items: any[];
   title: string;
+  /** For array cells. */
+  items?: any[];
+  /** For object cells. */
+  object?: Record<string, any>;
 }
+
+// Recursive, human-readable renderer for nested values in the detail modal —
+// primitives, arrays (of primitives → inline; of objects → blocks) and objects
+// (key/value rows), so nothing ever shows "[object Object]".
+const RenderValue: React.FC<{ value: any; depth?: number }> = ({
+  value,
+  depth = 0,
+}) => {
+  if (value === null || value === undefined || value === "") {
+    return <span className="text-gray-400 italic">Not recorded</span>;
+  }
+  if (typeof value === "boolean") {
+    return <span className="text-gray-900">{value ? "Yes" : "No"}</span>;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className="text-gray-400 italic">None</span>;
+    }
+    const allPrimitive = value.every(
+      (v) => v === null || typeof v !== "object",
+    );
+    if (allPrimitive) {
+      return (
+        <span className="text-gray-900 break-words">
+          {value.map((v) => String(v)).join(", ")}
+        </span>
+      );
+    }
+    return (
+      <div className="space-y-2">
+        {value.map((item, i) => (
+          <div
+            key={i}
+            className="rounded-md border border-gray-100 bg-gray-50/60 p-2"
+          >
+            <div className="text-[10px] uppercase tracking-wide text-gray-400 mb-1">
+              Item {i + 1}
+            </div>
+            <RenderValue value={item} depth={depth + 1} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      return <span className="text-gray-400 italic">Empty</span>;
+    }
+    return (
+      <div
+        className={
+          depth > 0 ? "space-y-1.5 pl-3 border-l border-gray-100" : "space-y-2"
+        }
+      >
+        {entries.map(([k, v]) => (
+          <div
+            key={k}
+            className="grid grid-cols-[minmax(7rem,11rem)_1fr] gap-3 items-start"
+          >
+            <span className="text-[13px] font-medium text-gray-500 break-words">
+              {humanizeKey(k)}
+            </span>
+            <span className="text-[13.5px] text-gray-900 break-words">
+              <RenderValue value={v} depth={depth + 1} />
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return <span className="text-gray-900 break-words">{String(value)}</span>;
+};
 
 // Component for displaying complex data (arrays and objects)
 const ComplexDataCell: React.FC<{
@@ -176,7 +253,7 @@ const ComplexDataCell: React.FC<{
             onArrayClick({
               columnKey,
               items: value,
-              title: `${columnKey} (${value.length} items)`,
+              title: `${humanizeKey(columnKey)} (${value.length} items)`,
             })
           }
           className="p-0 h-auto text-blue-600 hover:text-blue-800"
@@ -214,36 +291,28 @@ const ComplexDataCell: React.FC<{
     );
   }
 
-  // Handle objects
+  // Handle objects — match the array treatment: a count chip that opens the
+  // full key/value breakdown in the detail modal.
   if (typeof value === "object" && value !== null) {
     const entries = Object.entries(value);
     if (entries.length === 0) {
       return <span className="text-gray-400">{"{}"}</span>;
     }
-
-    // Show first 2 key-value pairs + count if more
-    const maxDisplay = 2;
-    const displayEntries = entries.slice(0, maxDisplay);
-    const remainingCount = entries.length - maxDisplay;
-
     return (
-      <div className="text-xs truncate block" title={JSON.stringify(value)}>
-        <span className="truncate block">
-          {displayEntries.map(([key, val], index) => (
-            <span key={index}>
-              <span className="font-medium text-gray-600">{key}:</span>{" "}
-              <span className="text-gray-900">"{String(val)}"</span>
-              {index < displayEntries.length - 1 && ", "}
-            </span>
-          ))}
-          {remainingCount > 0 && (
-            <span className="text-blue-600 font-medium">
-              {" "}
-              +{remainingCount} more
-            </span>
-          )}
-        </span>
-      </div>
+      <AntButton
+        type="link"
+        size="small"
+        onClick={() =>
+          onArrayClick({
+            columnKey,
+            title: `${humanizeKey(columnKey)} (${entries.length} field${entries.length === 1 ? "" : "s"})`,
+            object: value,
+          })
+        }
+        className="p-0 h-auto text-blue-600 hover:text-blue-800"
+      >
+        {entries.length} field{entries.length === 1 ? "" : "s"}
+      </AntButton>
     );
   }
 
@@ -1403,38 +1472,22 @@ const PreviewPage: React.FC = () => {
         style={{ top: 20 }}
       >
         <div className="max-h-[60vh] overflow-y-auto">
-          <div className="divide-y divide-gray-200">
-            {arrayPopup?.items.map((item, index) => (
-              <div key={index} className="px-4 py-3 hover:bg-gray-50">
-                <div className="flex items-center justify-between mb-3">
-                  <span className="text-sm font-medium text-gray-500 uppercase tracking-wider">
+          {arrayPopup?.object ? (
+            <div className="px-4 py-3">
+              <RenderValue value={arrayPopup.object} />
+            </div>
+          ) : (
+            <div className="divide-y divide-gray-200">
+              {arrayPopup?.items?.map((item, index) => (
+                <div key={index} className="px-4 py-3 hover:bg-gray-50">
+                  <div className="text-[11px] font-medium text-gray-400 uppercase tracking-wider mb-2">
                     Item {index + 1}
-                  </span>
+                  </div>
+                  <RenderValue value={item} depth={1} />
                 </div>
-                <div className="text-sm text-gray-900">
-                  {typeof item === "object" && item !== null ? (
-                    <div className="space-y-2">
-                      {Object.entries(item).map(([key, val]) => (
-                        <div
-                          key={key}
-                          className="flex border-b border-gray-100 pb-1 last:border-b-0"
-                        >
-                          <span className="font-medium text-gray-600 flex-shrink-0 mr-3 w-24">
-                            {key}:
-                          </span>
-                          <span className="text-gray-900 break-words">
-                            {String(val)}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="break-words">{String(item)}</span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       </Modal>
 

--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useMemo, useCallback } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, usePathname, useSearchParams } from "next/navigation";
 import { apiClient, PreviewDataTable, PreviewJobFile } from "@/lib/api";
 import {
   getCachedPreviewData,
@@ -15,11 +15,19 @@ import {
   Modal,
   Button as AntButton,
   Dropdown,
+  Drawer,
   Tag,
   Tooltip,
   notification,
   Spin,
 } from "antd";
+import { RecordView } from "@/components/record/RecordView";
+import {
+  PreviewRail,
+  PreviewView,
+  documentTypeLabel,
+} from "./PreviewRail";
+import { parsePreviewUrl, buildPreviewParams } from "./previewUrlState";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
 import {
   SearchOutlined,
@@ -250,14 +258,27 @@ const ComplexDataCell: React.FC<{
 const PreviewPage: React.FC = () => {
   const params = useParams();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const previewId = params.id as string;
+
+  // Initial page/per_page/slug/view come from the URL (so they're shareable).
+  const initialUrlRef = React.useRef<ReturnType<typeof parsePreviewUrl> | null>(
+    null,
+  );
+  if (!initialUrlRef.current) {
+    initialUrlRef.current = parsePreviewUrl(
+      new URLSearchParams(searchParams?.toString() ?? ""),
+    );
+  }
+  const initialUrl = initialUrlRef.current;
 
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
+  const [currentPage, setCurrentPage] = useState(initialUrl.page);
+  const [pageSize, setPageSize] = useState(initialUrl.pageSize);
   const [totalItems, setTotalItems] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [searchInput, setSearchInput] = useState("");
@@ -280,6 +301,20 @@ const PreviewPage: React.FC = () => {
   const [wellboreModalOpen, setWellboreModalOpen] = useState(false);
   const [selectedWellData, setSelectedWellData] = useState<any>(null);
   const [selectedFilename, setSelectedFilename] = useState<string>("");
+
+  // Rail navigation: which lens is active.
+  const [view, setView] = useState<PreviewView>(initialUrl.view);
+  const [slugs, setSlugs] = useState<
+    Array<{ slug: string | null; count: number }>
+  >([]);
+  const [fileSummaries, setFileSummaries] = useState<any[]>([]);
+  const [filesTotal, setFilesTotal] = useState<number>(0);
+
+  // Record detail drawer (RecordView engine + hero). The preview is a PUBLIC
+  // page, so we don't fetch the per-type schema from an authed endpoint — we
+  // reuse the preview's own (public) schema for labels and let the engine's
+  // data-driven fallback + slug-based hero handle the rest.
+  const [recordDrawer, setRecordDrawer] = useState<any>(null);
 
   useEffect(() => {
     document.title = previewData?.preview.name ?? "Preview";
@@ -351,9 +386,17 @@ const PreviewPage: React.FC = () => {
                   />
                 </Tooltip>
               )}
-              <span className="text-gray-900 truncate block" title={text}>
+              <button
+                type="button"
+                className="text-blue-600 hover:text-blue-800 hover:underline truncate block text-left bg-transparent border-0 p-0 cursor-pointer"
+                title={`View ${text}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setRecordDrawer(record);
+                }}
+              >
                 {text}
-              </span>
+              </button>
             </div>
           );
         },
@@ -481,8 +524,14 @@ const PreviewPage: React.FC = () => {
     if (!previewData?.jobFiles) return [];
 
     const data = previewData.jobFiles.map((file) => ({
+      // _rowId is unique per record; _fileId is the originating file (V2 files
+      // contribute many records, so these differ).
+      _rowId: file.id,
+      _record: file.result, // raw record, for the RecordView detail drawer
       _filename: file.filename,
-      _fileId: file.id,
+      _fileId: file.file_id ?? file.id,
+      _slug: file.slug ?? null,
+      _sectionId: file.section_result_id ?? null,
       _jobName: file.job_name,
       _createdAt: file.created_at,
       _adminVerified: file.admin_verified || false,
@@ -543,15 +592,40 @@ const PreviewPage: React.FC = () => {
           clearPreviewCache(previewId);
         }
 
-        // Check cache first (unless forcing refresh)
-        if (!forceRefresh) {
+        // "By file" lens — file summaries (no record cache).
+        if (view.kind === "files") {
+          const resp = await apiClient.getPreviewFiles(
+            previewId,
+            currentPage,
+            pageSize,
+            searchTerm || undefined,
+          );
+          if (resp.success && resp.data) {
+            setFileSummaries(resp.data.files);
+            setFilesTotal(resp.data.pagination.total);
+            setTotalItems(resp.data.pagination.total);
+            setTotalPages(resp.data.pagination.totalPages);
+          } else {
+            setError("Failed to load files");
+          }
+          setLoading(false);
+          return;
+        }
+
+        // Record lenses (all / by type / scoped to one file).
+        const slugFilter = view.kind === "records" ? view.slug : undefined;
+        const fileFilter = view.kind === "file" ? view.fileId : undefined;
+        // Only the unfiltered "all records" view uses the page cache.
+        const useCache =
+          !forceRefresh && view.kind === "records" && !view.slug;
+
+        if (useCache) {
           const cached = getCachedPreviewData(
             previewId,
             currentPage,
             pageSize,
             searchTerm || undefined,
           );
-
           if (cached) {
             setPreviewData({
               preview: cached.preview,
@@ -564,12 +638,12 @@ const PreviewPage: React.FC = () => {
           }
         }
 
-        // Fetch from API
         const response = await apiClient.getPreviewDataPaginated(
           previewId,
           currentPage,
           pageSize,
           searchTerm || undefined,
+          { slug: slugFilter, fileId: fileFilter },
         );
 
         if (response.success && response.data) {
@@ -579,19 +653,21 @@ const PreviewPage: React.FC = () => {
           });
           setTotalItems(response.data.pagination.total);
           setTotalPages(response.data.pagination.totalPages);
+          if (response.data.slugs) setSlugs(response.data.slugs);
 
-          // Cache the result
-          setCachedPreviewData(
-            previewId,
-            currentPage,
-            pageSize,
-            {
-              preview: response.data.preview,
-              jobFiles: response.data.jobFiles,
-              pagination: response.data.pagination,
-            },
-            searchTerm || undefined,
-          );
+          if (useCache) {
+            setCachedPreviewData(
+              previewId,
+              currentPage,
+              pageSize,
+              {
+                preview: response.data.preview,
+                jobFiles: response.data.jobFiles,
+                pagination: response.data.pagination,
+              },
+              searchTerm || undefined,
+            );
+          }
         } else {
           setError("Failed to load preview data");
         }
@@ -602,8 +678,30 @@ const PreviewPage: React.FC = () => {
         setLoading(false);
       }
     },
-    [previewId, currentPage, pageSize, searchTerm],
+    [previewId, currentPage, pageSize, searchTerm, view],
   );
+
+  // Reset to the first page whenever the rail view changes (but not on the
+  // initial mount, so a `page` restored from the URL isn't clobbered).
+  const firstViewRef = React.useRef(true);
+  useEffect(() => {
+    if (firstViewRef.current) {
+      firstViewRef.current = false;
+      return;
+    }
+    setCurrentPage(1);
+  }, [view]);
+
+  // Persist page / per_page / slug / view in the URL (shareable, restored on load).
+  useEffect(() => {
+    const next = buildPreviewParams(new URLSearchParams(), {
+      page: currentPage,
+      pageSize,
+      view,
+    });
+    const qs = next.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [currentPage, pageSize, view, pathname, router]);
 
   // Force refresh function
   const handleRefresh = useCallback(async () => {
@@ -1024,45 +1122,144 @@ const PreviewPage: React.FC = () => {
         </div>
       </div>
 
-      {/* Scrollable Content */}
-      <div className="flex-1 overflow-hidden">
-        <Table
-          columns={tableColumns}
-          bordered
-          dataSource={processedData}
-          rowKey={(record) => `${record._fileId}-${record._filename}`}
-          scroll={{ x: "max-content", y: "calc(100vh - 200px)" }}
-          loading={loading}
-          pagination={
-            totalItems > 0 && !loading && processedData.length <= pageSize
-              ? {
-                  current: currentPage,
-                  total: totalItems,
-                  pageSize: pageSize,
-                  showSizeChanger: true,
-                  showQuickJumper: false,
-                  showTotal: (total, range) =>
-                    `${range[0]}-${range[1]} of ${total} items`,
-                  onChange: (page, size) => {
-                    setCurrentPage(page);
-                    if (size !== pageSize) {
-                      setPageSize(size);
-                    }
-                  },
-                  onShowSizeChange: (current, size) => {
-                    setCurrentPage(1);
-                    setPageSize(size);
-                  },
-                  size: "small",
-                  hideOnSinglePage: totalPages <= 1,
-                  position: ["bottomCenter"],
-                  pageSizeOptions: ["10", "20", "50", "100"],
-                }
-              : false
-          }
-          size="small"
-          className="ant-table-custom h-full"
+      {/* Scrollable Content with rail */}
+      <div className="flex-1 overflow-hidden flex">
+        <PreviewRail
+          slugs={slugs}
+          totalRecords={slugs.reduce((a, s) => a + s.count, 0) || undefined}
+          totalFiles={filesTotal || undefined}
+          view={view}
+          onSelect={setView}
         />
+        <div className="flex-1 overflow-hidden flex flex-col">
+          {view.kind === "file" && (
+            <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-100 text-sm bg-white">
+              <button
+                type="button"
+                className="text-blue-600 hover:underline bg-transparent border-0 p-0 cursor-pointer"
+                onClick={() => setView({ kind: "files" })}
+              >
+                ← Files
+              </button>
+              <span className="text-gray-400">/</span>
+              <span className="text-gray-700 truncate">{view.filename}</span>
+            </div>
+          )}
+
+          {view.kind === "files" ? (
+            <Table
+              columns={[
+                {
+                  title: "File",
+                  dataIndex: "filename",
+                  key: "filename",
+                  ellipsis: true,
+                  render: (text: string, f: any) => (
+                    <button
+                      type="button"
+                      className="text-blue-600 hover:text-blue-800 hover:underline text-left bg-transparent border-0 p-0 cursor-pointer truncate block"
+                      title={`Open ${text}`}
+                      onClick={() =>
+                        setView({
+                          kind: "file",
+                          fileId: f.id,
+                          filename: f.filename,
+                        })
+                      }
+                    >
+                      {text}
+                    </button>
+                  ),
+                },
+                {
+                  title: "Contents",
+                  key: "contents",
+                  render: (_: unknown, f: any) =>
+                    f.by_type && f.by_type.length
+                      ? f.by_type
+                          .map(
+                            (t: { slug: string | null; count: number }) =>
+                              `${t.count} ${documentTypeLabel(t.slug)}`,
+                          )
+                          .join(" · ")
+                      : `${f.total_records} records`,
+                },
+                {
+                  title: "Records",
+                  dataIndex: "total_records",
+                  key: "total_records",
+                  width: 90,
+                  align: "right" as const,
+                },
+                {
+                  title: "Status",
+                  dataIndex: "review_status",
+                  key: "review_status",
+                  width: 120,
+                  render: (s: string) => <Tag>{s || "pending"}</Tag>,
+                },
+              ]}
+              dataSource={fileSummaries}
+              rowKey="id"
+              loading={loading}
+              scroll={{ y: "calc(100vh - 200px)" }}
+              pagination={
+                filesTotal > pageSize
+                  ? {
+                      current: currentPage,
+                      total: filesTotal,
+                      pageSize,
+                      onChange: (p) => setCurrentPage(p),
+                      size: "small",
+                      position: ["bottomCenter"],
+                    }
+                  : false
+              }
+              size="small"
+              className="ant-table-custom"
+            />
+          ) : (
+            <Table
+              columns={tableColumns}
+              bordered
+              dataSource={processedData}
+              rowKey={(record) =>
+                record._rowId ?? `${record._fileId}-${record._filename}`
+              }
+              scroll={{ x: "max-content", y: "calc(100vh - 200px)" }}
+              loading={loading}
+              pagination={
+                totalItems > 0 && !loading && processedData.length <= pageSize
+                  ? {
+                      current: currentPage,
+                      total: totalItems,
+                      pageSize: pageSize,
+                      showSizeChanger: true,
+                      showQuickJumper: false,
+                      showTotal: (total, range) =>
+                        `${range[0]}-${range[1]} of ${total} items`,
+                      onChange: (page, size) => {
+                        setCurrentPage(page);
+                        if (size !== pageSize) {
+                          setPageSize(size);
+                        }
+                      },
+                      onShowSizeChange: (current, size) => {
+                        setCurrentPage(1);
+                        setPageSize(size);
+                      },
+                      size: "small",
+                      hideOnSinglePage: totalPages <= 1,
+                      position: ["bottomCenter"],
+                      pageSizeOptions: ["10", "20", "50", "100"],
+                    }
+                  : false
+              }
+              size="small"
+              className="ant-table-custom h-full"
+            />
+          )}
+        </div>
       </div>
 
       {/* Quality Score Info Modal */}
@@ -1240,6 +1437,33 @@ const PreviewPage: React.FC = () => {
           </div>
         </div>
       </Modal>
+
+      {/* Record detail drawer — the schema-driven RecordView (engine + hero) */}
+      <Drawer
+        open={!!recordDrawer}
+        onClose={() => setRecordDrawer(null)}
+        width={920}
+        title={recordDrawer?._filename}
+        styles={{ body: { background: "#f9fafb" } }}
+        destroyOnClose
+      >
+        {recordDrawer && (
+          <RecordView
+            data={recordDrawer._record ?? recordDrawer}
+            schema={previewData?.preview?.schema as never}
+            slug={recordDrawer._slug ?? undefined}
+            trust={{
+              verification:
+                recordDrawer._reviewStatus === "approved"
+                  ? "approved"
+                  : recordDrawer._reviewStatus === "rejected"
+                    ? "rejected"
+                    : "pending",
+              qa: null,
+            }}
+          />
+        )}
+      </Drawer>
 
       {/* Wellbore Diagram Drawer */}
       <WellboreDiagramDrawer

--- a/src/app/preview/[id]/previewUrlState.ts
+++ b/src/app/preview/[id]/previewUrlState.ts
@@ -1,0 +1,67 @@
+import { PreviewView } from "./PreviewRail";
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 20;
+
+export interface PreviewUrlState {
+  page: number;
+  pageSize: number;
+  view: PreviewView;
+}
+
+function posInt(raw: string | null, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Read page / per_page / slug / view (+ file) from the URL. */
+export function parsePreviewUrl(params: URLSearchParams): PreviewUrlState {
+  const page = posInt(params.get("page"), DEFAULT_PAGE);
+  const pageSize = posInt(params.get("per_page"), DEFAULT_PAGE_SIZE);
+  const viewParam = params.get("view");
+  const file = params.get("file");
+  const slug = params.get("slug");
+
+  let view: PreviewView;
+  if (viewParam === "files") {
+    view = file ? { kind: "file", fileId: file, filename: "" } : { kind: "files" };
+  } else if (slug) {
+    view = { kind: "records", slug };
+  } else {
+    view = { kind: "records" };
+  }
+  return { page, pageSize, view };
+}
+
+/** Merge page / per_page / slug / view into the current params, dropping defaults. */
+export function buildPreviewParams(
+  current: URLSearchParams,
+  patch: { page?: number; pageSize?: number; view?: PreviewView },
+): URLSearchParams {
+  const next = new URLSearchParams(current.toString());
+
+  if (patch.page !== undefined) {
+    if (patch.page <= DEFAULT_PAGE) next.delete("page");
+    else next.set("page", String(patch.page));
+  }
+  if (patch.pageSize !== undefined) {
+    if (patch.pageSize === DEFAULT_PAGE_SIZE) next.delete("per_page");
+    else next.set("per_page", String(patch.pageSize));
+  }
+  if (patch.view !== undefined) {
+    const v = patch.view;
+    next.delete("view");
+    next.delete("file");
+    next.delete("slug");
+    if (v.kind === "files") {
+      next.set("view", "files");
+    } else if (v.kind === "file") {
+      next.set("view", "files");
+      next.set("file", v.fileId);
+    } else if (v.kind === "records" && v.slug) {
+      next.set("slug", v.slug);
+    }
+  }
+  return next;
+}

--- a/src/components/record/RecordBody.tsx
+++ b/src/components/record/RecordBody.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React from "react";
+import {
+  JsonSchemaNode,
+  classifyValue,
+  isProseField,
+  labelForField,
+  normalizeSchemaNode,
+  orderedKeys,
+} from "./recordSchema";
+import {
+  AttributeCard,
+  ChipList,
+  FieldBlock,
+  RecordTable,
+  RenderCtx,
+  ScalarValue,
+} from "./renderers";
+
+const childSchema = (
+  node: JsonSchemaNode | undefined,
+  key: string,
+): JsonSchemaNode | undefined => normalizeSchemaNode(node?.properties?.[key]).node;
+
+/**
+ * Generic body: lays out a record's top-level fields. Loose scalars are grouped
+ * into a "Details" card; objects become attribute cards; arrays of objects
+ * become full-width tables. Order follows the schema, then data-only extras.
+ */
+export function RecordBody({
+  data,
+  schema,
+  ctx,
+}: {
+  data: Record<string, unknown>;
+  schema?: JsonSchemaNode;
+  ctx: RenderCtx;
+}) {
+  const keys = orderedKeys(data, schema);
+
+  const looseScalars = keys.filter((k) => {
+    const t = classifyValue(data[k]);
+    return (t === "scalar" || t === "empty") && !isProseField(k, data[k]);
+  });
+  const rest = keys.filter((k) => !looseScalars.includes(k));
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {looseScalars.length > 0 && (
+        <DetailsCard data={data} schema={schema} keys={looseScalars} />
+      )}
+
+      {rest.map((k) => {
+        const t = classifyValue(data[k]);
+        const fullWidth = t === "objectArray" || isProseField(k, data[k]);
+        return (
+          <div key={k} className={fullWidth ? "lg:col-span-2" : ""}>
+            <FieldBlock
+              fieldKey={k}
+              value={data[k]}
+              schema={childSchema(schema, k)}
+              path={[k]}
+              ctx={ctx}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// A "Details" card collecting all loose top-level scalar fields.
+function DetailsCard({
+  data,
+  schema,
+  keys,
+}: {
+  data: Record<string, unknown>;
+  schema?: JsonSchemaNode;
+  keys: string[];
+}) {
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white">
+      <header className="px-4 pt-3 pb-2 border-b border-gray-100">
+        <h3 className="text-[13px] font-semibold tracking-wide text-gray-700 uppercase">
+          Details
+        </h3>
+      </header>
+      <div className="p-4">
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2.5">
+          {keys.map((k) => (
+            <div key={k} className="flex flex-col gap-0.5 min-w-0">
+              <span className="text-[13px] text-gray-500">
+                {labelForField(k, childSchema(schema, k))}
+              </span>
+              <dd className="m-0 break-words">
+                {classifyValue(data[k]) === "scalarArray" ? (
+                  <ChipList values={data[k] as unknown[]} />
+                ) : (
+                  <ScalarValue fieldKey={k} value={data[k]} />
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+// Re-export so RecordView can pull both from one module if desired.
+export { AttributeCard, RecordTable };

--- a/src/components/record/RecordTrustHeader.tsx
+++ b/src/components/record/RecordTrustHeader.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import React from "react";
+import type {
+  QAOverallQuality,
+  SectionVerificationStatus,
+} from "@/lib/api";
+import { humanizeKey } from "./recordSchema";
+
+export interface RecordTrust {
+  verification?: SectionVerificationStatus | null;
+  qa?: { quality: QAOverallQuality | null; openFindings: number } | null;
+}
+
+// Friendly document-type names (fallback humanizes the slug).
+const SLUG_NAMES: Record<string, string> = {
+  mgs_well_log: "Well Log",
+  borehole_log: "Boring Log",
+  aquifer_test: "Aquifer Test",
+  analytical_results: "Analytical Results",
+  well_coordinate_table: "Well Coordinates",
+  field_sampling_forms: "Field Sampling",
+};
+
+type Tone = "good" | "warn" | "bad" | "neutral";
+const TONE: Record<Tone, string> = {
+  good: "bg-green-50 text-green-700 ring-green-600/15",
+  warn: "bg-amber-50 text-amber-700 ring-amber-600/15",
+  bad: "bg-red-50 text-red-700 ring-red-600/15",
+  neutral: "bg-gray-100 text-gray-600 ring-gray-500/10",
+};
+
+function Chip({
+  tone,
+  icon,
+  children,
+}: {
+  tone: Tone;
+  icon?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[12px] font-medium ring-1 ring-inset ${TONE[tone]}`}
+    >
+      {icon && <span className="text-[11px] leading-none">{icon}</span>}
+      {children}
+    </span>
+  );
+}
+
+function pick(obj: unknown, path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const p of path) {
+    if (cur && typeof cur === "object" && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else return undefined;
+  }
+  return cur;
+}
+
+function recordTitle(data: Record<string, unknown>): string | null {
+  const candidates: Array<unknown> = [
+    pick(data, ["site_identification", "boring_well_id"]),
+    pick(data, ["site_identification", "boring_well_id_full"]),
+    pick(data, ["test_setup", "well_number"]),
+    data["well_number"],
+    data["api_number"],
+    data["boring_well_id"],
+    data["location_id"],
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim()) return c.trim();
+    if (typeof c === "number") return String(c);
+  }
+  return null;
+}
+
+function confidenceChip(conf: unknown): React.ReactNode {
+  if (typeof conf !== "number") return null;
+  const pct = conf <= 1 ? conf : conf / 100;
+  const tone: Tone = pct >= 0.85 ? "good" : pct >= 0.6 ? "warn" : "bad";
+  const label =
+    pct >= 0.85 ? "High confidence" : pct >= 0.6 ? "Medium confidence" : "Low confidence";
+  return (
+    <Chip tone={tone} icon="◆">
+      {label}
+    </Chip>
+  );
+}
+
+function qaChip(qa: RecordTrust["qa"]): React.ReactNode {
+  if (!qa) return null;
+  if (qa.openFindings > 0) {
+    return (
+      <Chip tone="warn" icon="!">
+        {qa.openFindings} item{qa.openFindings === 1 ? "" : "s"} to review
+      </Chip>
+    );
+  }
+  if (qa.quality === "poor") return <Chip tone="bad" icon="!">Quality concerns</Chip>;
+  if (qa.quality) return <Chip tone="good" icon="✓">No issues</Chip>;
+  return <Chip tone="neutral">Not checked</Chip>;
+}
+
+function verificationChip(
+  status: RecordTrust["verification"],
+): React.ReactNode {
+  switch (status) {
+    case "approved":
+      return <Chip tone="good" icon="✓">Verified</Chip>;
+    case "rejected":
+      return <Chip tone="bad" icon="✕">Rejected</Chip>;
+    case "in_review":
+      return <Chip tone="warn">In review</Chip>;
+    default:
+      return <Chip tone="neutral">Needs review</Chip>;
+  }
+}
+
+export function RecordTrustHeader({
+  data,
+  slug,
+  trust,
+}: {
+  data: Record<string, unknown>;
+  slug?: string;
+  trust?: RecordTrust;
+}) {
+  const docName = slug ? SLUG_NAMES[slug] ?? humanizeKey(slug) : "Record";
+  const title = recordTitle(data);
+
+  const meta = (data["extraction_metadata"] ?? {}) as Record<string, unknown>;
+  const rawSource =
+    typeof meta.source_file === "string" ? meta.source_file.trim() : "";
+  const sourceFile =
+    rawSource && rawSource.toLowerCase() !== "unknown" ? rawSource : null;
+  const pages = Array.isArray(meta.source_pages)
+    ? (meta.source_pages as number[]).filter((n) => typeof n === "number")
+    : [];
+  const pageLabel =
+    pages.length === 1
+      ? `Page ${pages[0]}`
+      : pages.length > 1
+        ? `Pages ${Math.min(...pages)}–${Math.max(...pages)}`
+        : null;
+
+  // Only surface scan quality when it signals a problem (a clean scan needs no
+  // note). Avoid double "scan" when the value already contains the word.
+  const scanRaw =
+    typeof meta.scan_quality === "string" ? meta.scan_quality : null;
+  const scanConcern =
+    scanRaw && /poor|fair|low|illegible|degraded|faint|light|blurr|skew/i.test(scanRaw)
+      ? /scan/i.test(scanRaw)
+        ? humanizeKey(scanRaw)
+        : `${humanizeKey(scanRaw)} scan`
+      : null;
+  const handwritten = meta.handwritten === true;
+
+  return (
+    <header className="flex flex-col gap-3 pb-4 mb-4 border-b border-gray-200">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-blue-600">
+            {docName}
+          </div>
+          <h2 className="text-xl font-semibold text-gray-900 truncate">
+            {title ?? docName}
+          </h2>
+          {(sourceFile || pageLabel) && (
+            <div className="text-[12.5px] text-gray-400 mt-0.5 truncate">
+              {[sourceFile, pageLabel].filter(Boolean).join(" · ")}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 flex-wrap">
+          {confidenceChip(meta.extraction_confidence)}
+          {qaChip(trust?.qa)}
+          {verificationChip(trust?.verification)}
+        </div>
+      </div>
+
+      {scanConcern || handwritten ? (
+        <div className="flex items-center gap-2 flex-wrap">
+          {handwritten && (
+            <span className="text-[11px] text-gray-500 bg-gray-100 rounded px-1.5 py-0.5">
+              Handwritten source
+            </span>
+          )}
+          {scanConcern && (
+            <span className="text-[11px] text-amber-700 bg-amber-50 rounded px-1.5 py-0.5">
+              {scanConcern}
+            </span>
+          )}
+        </div>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/record/RecordView.tsx
+++ b/src/components/record/RecordView.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { buildFieldDescriptionMap } from "@/lib/schemaDescriptions";
+import { JsonSchemaNode } from "./recordSchema";
+import { RecordBody } from "./RecordBody";
+import { RecordTrustHeader, RecordTrust } from "./RecordTrustHeader";
+import { heroForSlug, HeroComponent } from "./heroes";
+import type { RenderCtx } from "./renderers";
+
+/**
+ * Customer-facing record viewer. Renders any record from its data (+ optional
+ * JSON Schema) as a human-readable report: a trust header, an optional tailored
+ * "hero" visualization, then the schema-driven body. No raw keys/JSON.
+ */
+export function RecordView({
+  data,
+  schema,
+  slug,
+  fieldDescriptions,
+  trust,
+  hero,
+}: {
+  data: Record<string, unknown>;
+  schema?: JsonSchemaNode;
+  slug?: string;
+  fieldDescriptions?: Record<string, string>;
+  trust?: RecordTrust;
+  /** Override the registry hero (e.g. for testing). */
+  hero?: HeroComponent | null;
+}) {
+  const descMap = useMemo<Record<string, string>>(
+    () => fieldDescriptions ?? (schema ? buildFieldDescriptionMap(schema) : {}),
+    [fieldDescriptions, schema],
+  );
+  const ctx: RenderCtx = { descMap };
+
+  const Hero = hero !== undefined ? hero : heroForSlug(slug);
+
+  if (!data || typeof data !== "object") {
+    return (
+      <div className="p-8 text-center text-gray-400 text-sm">
+        Nothing to display for this record.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-1 py-2">
+      <RecordTrustHeader data={data} slug={slug} trust={trust} />
+      {Hero && (
+        <div className="mb-5">
+          <Hero data={data} />
+        </div>
+      )}
+      <RecordBody data={data} schema={schema} ctx={ctx} />
+    </div>
+  );
+}
+
+export default RecordView;

--- a/src/components/record/heroes/AquiferTestHero.tsx
+++ b/src/components/record/heroes/AquiferTestHero.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React from "react";
+import {
+  Chart as ChartJS,
+  LinearScale,
+  LogarithmicScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Scatter } from "react-chartjs-2";
+import { formatScalar, humanizeKey } from "../recordSchema";
+
+ChartJS.register(
+  LinearScale,
+  LogarithmicScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
+
+const SERIES = [
+  { key: "drawdown_ft", label: "Drawdown (ft)", color: "#2563eb" },
+  { key: "recovery_ft", label: "Recovery (ft)", color: "#16a34a" },
+  { key: "water_level_ft", label: "Water level (ft)", color: "#0891b2" },
+];
+
+const PARAM_KEYS = [
+  "aquifer_type",
+  "analysis_method",
+  "transmissivity_ft2_day",
+  "storativity",
+  "specific_capacity_gpm_ft",
+  "well_efficiency_percent",
+];
+
+/**
+ * aquifer_test hero — elapsed-time vs drawdown/recovery on a log-time axis, plus
+ * a calculated-parameters summary. The generic body still shows the full
+ * readings table below.
+ */
+export function AquiferTestHero({ data }: { data: Record<string, unknown> }) {
+  const readings = Array.isArray(data.time_series_readings)
+    ? (data.time_series_readings as Array<Record<string, unknown>>)
+    : [];
+
+  const datasets = SERIES.map((s) => {
+    const points = readings
+      .map((r) => ({ x: r.elapsed_time, y: r[s.key] }))
+      .filter(
+        (p) =>
+          typeof p.x === "number" && p.x > 0 && typeof p.y === "number",
+      ) as Array<{ x: number; y: number }>;
+    return { ...s, points };
+  }).filter((s) => s.points.length >= 2);
+
+  const params = (data.calculated_parameters ?? {}) as Record<string, unknown>;
+  const paramEntries = PARAM_KEYS.filter(
+    (k) => params[k] !== null && params[k] !== undefined && params[k] !== "",
+  );
+
+  if (datasets.length === 0 && paramEntries.length === 0) return null;
+
+  const chartData = {
+    datasets: datasets.map((s) => ({
+      label: s.label,
+      data: s.points,
+      borderColor: s.color,
+      backgroundColor: s.color,
+      showLine: true,
+      pointRadius: 2,
+      borderWidth: 1.5,
+      tension: 0.2,
+    })),
+  };
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-4 flex flex-col gap-4">
+      <h3 className="text-[13px] font-semibold tracking-wide text-gray-700 uppercase">
+        Test Response
+      </h3>
+
+      {datasets.length > 0 && (
+        <div style={{ height: 320 }}>
+          <Scatter
+            data={chartData}
+            options={{
+              responsive: true,
+              maintainAspectRatio: false,
+              interaction: { mode: "nearest", intersect: false },
+              scales: {
+                x: {
+                  type: "logarithmic",
+                  title: { display: true, text: "Elapsed time (min)" },
+                },
+                y: { title: { display: true, text: "Feet" } },
+              },
+              plugins: { legend: { position: "bottom" } },
+            }}
+          />
+        </div>
+      )}
+
+      {paramEntries.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {paramEntries.map((k) => (
+            <div
+              key={k}
+              className="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2"
+            >
+              <div className="text-[11px] text-gray-500">{humanizeKey(k)}</div>
+              <div className="text-[14px] font-medium text-gray-900 tabular-nums">
+                {formatScalar(k, params[k])}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/record/heroes/BoreholeLogHero.tsx
+++ b/src/components/record/heroes/BoreholeLogHero.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import React from "react";
+
+interface Interval {
+  depth_from_ft?: number | null;
+  depth_to_ft?: number | null;
+  primary_material?: string | null;
+  uscs_symbol?: string | null;
+  color_description?: string | null;
+  description_raw?: string | null;
+}
+
+// Material → fill colour (USGS-ish, soft so text stays readable).
+const MATERIAL_COLORS: Array<{ test: RegExp; bg: string; fg: string }> = [
+  { test: /topsoil|organic/i, bg: "#5b4636", fg: "#fff" },
+  { test: /fill/i, bg: "#8d6e63", fg: "#fff" },
+  { test: /clay/i, bg: "#9fb0c3", fg: "#1f2937" },
+  { test: /silt/i, bg: "#cdb892", fg: "#1f2937" },
+  { test: /sand/i, bg: "#f4d58d", fg: "#3a2f0b" },
+  { test: /gravel|cobble/i, bg: "#e7a35a", fg: "#3a2f0b" },
+  { test: /till/i, bg: "#a3a86b", fg: "#1f2937" },
+  { test: /lime|dolomite|bedrock|rock|shale|sandstone/i, bg: "#9ca3af", fg: "#111827" },
+  { test: /peat/i, bg: "#6b4f2a", fg: "#fff" },
+];
+const colorFor = (m?: string | null) =>
+  (m && MATERIAL_COLORS.find((c) => c.test.test(m))) || {
+    bg: "#e5e7eb",
+    fg: "#374151",
+  };
+
+const COLUMN_HEIGHT = 520;
+const MIN_BAND = 30;
+
+/**
+ * borehole_log hero — a lithology depth column. Stratigraphic bands down a depth
+ * axis, coloured by material, labelled with material / USCS / depth. The generic
+ * body still renders the full interval table below.
+ */
+export function BoreholeLogHero({ data }: { data: Record<string, unknown> }) {
+  const intervals = (
+    Array.isArray(data.lithology_intervals)
+      ? (data.lithology_intervals as Interval[])
+      : []
+  ).filter((i) => typeof i.depth_from_ft === "number");
+
+  if (intervals.length === 0) return null;
+
+  const totalDepthField = (
+    data.drilling_and_personnel as Record<string, unknown> | undefined
+  )?.total_depth_ft;
+  const maxDepth = Math.max(
+    ...intervals.map((i) => i.depth_to_ft ?? i.depth_from_ft ?? 0),
+    typeof totalDepthField === "number" ? totalDepthField : 0,
+  );
+  const minDepth = Math.min(...intervals.map((i) => i.depth_from_ft ?? 0));
+  const span = Math.max(maxDepth - minDepth, 1);
+  const pxPerFt = COLUMN_HEIGHT / span;
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-4">
+      <h3 className="text-[13px] font-semibold tracking-wide text-gray-700 uppercase mb-3">
+        Lithology Profile
+      </h3>
+      <div className="flex gap-2" style={{ minHeight: COLUMN_HEIGHT }}>
+        {/* depth axis */}
+        <div
+          className="relative w-12 shrink-0 text-right pr-1"
+          style={{ height: COLUMN_HEIGHT }}
+        >
+          {intervals.map((iv, idx) => {
+            const top = ((iv.depth_from_ft ?? 0) - minDepth) * pxPerFt;
+            return (
+              <div
+                key={idx}
+                className="absolute right-1 -translate-y-1/2 text-[10px] text-gray-400 tabular-nums"
+                style={{ top }}
+              >
+                {iv.depth_from_ft}
+              </div>
+            );
+          })}
+          <div
+            className="absolute right-1 -translate-y-1/2 text-[10px] text-gray-400 tabular-nums"
+            style={{ top: COLUMN_HEIGHT }}
+          >
+            {maxDepth}
+          </div>
+          <div className="absolute -left-1 top-1/2 -translate-y-1/2 -rotate-90 text-[9px] uppercase tracking-wide text-gray-300">
+            Depth (ft)
+          </div>
+        </div>
+
+        {/* column */}
+        <div
+          className="relative flex-1 rounded-md overflow-hidden border border-gray-200"
+          style={{ height: COLUMN_HEIGHT }}
+        >
+          {intervals.map((iv, idx) => {
+            const from = iv.depth_from_ft ?? 0;
+            const to = iv.depth_to_ft ?? from;
+            const rawH = Math.max((to - from) * pxPerFt, MIN_BAND);
+            const top = (from - minDepth) * pxPerFt;
+            const c = colorFor(iv.primary_material);
+            const label =
+              iv.uscs_symbol ||
+              iv.primary_material ||
+              (iv.description_raw || "").slice(0, 28);
+            return (
+              <div
+                key={idx}
+                className="absolute left-0 right-0 px-2 flex items-center overflow-hidden border-b border-black/10"
+                style={{ top, height: rawH, background: c.bg, color: c.fg }}
+                title={iv.description_raw || undefined}
+              >
+                <span className="text-[11px] font-medium truncate capitalize">
+                  {label}
+                  {iv.color_description ? (
+                    <span className="opacity-70"> · {iv.color_description}</span>
+                  ) : null}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/record/heroes/MgsWellLogHero.tsx
+++ b/src/components/record/heroes/MgsWellLogHero.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import { WellboreDiagram, MGSWellData } from "@/components/well/WellboreDiagram";
+
+/**
+ * mgs_well_log hero — the existing wellbore construction diagram. The record IS
+ * the MGSWellData shape the diagram consumes. The generic body still renders the
+ * formations/casing/pluggings tables below (complementary data view).
+ */
+export function MgsWellLogHero({ data }: { data: Record<string, unknown> }) {
+  const well = data as unknown as MGSWellData;
+  const hasGeometry =
+    typeof well.true_depth === "number" ||
+    (Array.isArray(well.formations) && well.formations.length > 0) ||
+    (Array.isArray(well.casing) && well.casing.length > 0);
+  if (!hasGeometry) return null;
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-4 overflow-x-auto">
+      <h3 className="text-[13px] font-semibold tracking-wide text-gray-700 uppercase mb-3">
+        Wellbore Diagram
+      </h3>
+      <div className="flex justify-center">
+        <WellboreDiagram data={well} size="large" />
+      </div>
+    </section>
+  );
+}

--- a/src/components/record/heroes/index.ts
+++ b/src/components/record/heroes/index.ts
@@ -1,0 +1,24 @@
+import React from "react";
+import { MgsWellLogHero } from "./MgsWellLogHero";
+import { BoreholeLogHero } from "./BoreholeLogHero";
+import { AquiferTestHero } from "./AquiferTestHero";
+
+/**
+ * Hero registry. A "hero" is a tailored, top-of-record visualization for a slug
+ * with a natural shape (a well diagram, a depth column, a chart). It's a
+ * complementary Layer-2 visual — the generic engine still renders the data
+ * tables below. When no hero is registered, the record uses the generic body
+ * alone. Heroes must be defensive: render nothing when their data is missing.
+ */
+export type HeroComponent = React.ComponentType<{ data: Record<string, unknown> }>;
+
+const REGISTRY: Record<string, HeroComponent> = {
+  mgs_well_log: MgsWellLogHero,
+  borehole_log: BoreholeLogHero,
+  aquifer_test: AquiferTestHero,
+};
+
+export function heroForSlug(slug?: string | null): HeroComponent | null {
+  if (!slug) return null;
+  return REGISTRY[slug] ?? null;
+}

--- a/src/components/record/recordSchema.ts
+++ b/src/components/record/recordSchema.ts
@@ -1,0 +1,233 @@
+/**
+ * Pure helpers for the schema-driven record renderer. No React here.
+ *
+ * The engine is schema-AWARE but data-SAFE: it uses the JSON Schema for field
+ * order, labels, and units when available, and falls back to the data shape
+ * otherwise — so any record renders, registered schema or not.
+ */
+
+export type JsonSchemaNode = {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  properties?: Record<string, JsonSchemaNode>;
+  items?: JsonSchemaNode;
+  anyOf?: JsonSchemaNode[];
+  oneOf?: JsonSchemaNode[];
+  enum?: unknown[];
+  format?: string;
+  [k: string]: unknown;
+};
+
+export type FieldType =
+  | "scalar"
+  | "object"
+  | "objectArray"
+  | "scalarArray"
+  | "empty";
+
+// Keys that belong in the header / are internal plumbing — never in the body.
+export const INTERNAL_KEYS = new Set([
+  "section_result_id",
+  "record_id",
+  "extraction_metadata",
+  "source_locations",
+]);
+
+const ACRONYMS = new Set([
+  "id",
+  "uscs",
+  "spt",
+  "pid",
+  "voc",
+  "api",
+  "toc",
+  "swl",
+  "h2s",
+  "gw",
+  "n",
+  "ph",
+  "tvd",
+  "md",
+  "eob",
+]);
+
+// Unit suffixes, longest first so `_ft2_day` wins over `_ft`. `label` is the
+// human unit; matching suffix is stripped from the field name for the label.
+const UNIT_SUFFIXES: Array<{ suffix: string; label: string }> = [
+  { suffix: "_ft2_day", label: "ft²/day" },
+  { suffix: "_gpm_ft", label: "gpm/ft" },
+  { suffix: "_percent", label: "%" },
+  { suffix: "_ppm", label: "ppm" },
+  { suffix: "_ppb", label: "ppb" },
+  { suffix: "_gpm", label: "gpm" },
+  { suffix: "_tsf", label: "tsf" },
+  { suffix: "_dd", label: "°" },
+  { suffix: "_ft", label: "ft" },
+  { suffix: "_in", label: "in" },
+  { suffix: "_lb", label: "lb" },
+];
+
+/** Resolve `anyOf: [{type:X},{type:null}]` (and string[] types) → base + nullable. */
+export function normalizeSchemaNode(node?: JsonSchemaNode): {
+  type?: string;
+  nullable: boolean;
+  node?: JsonSchemaNode;
+} {
+  if (!node) return { nullable: true };
+  const variants = node.anyOf || node.oneOf;
+  if (Array.isArray(variants)) {
+    let nullable = false;
+    let base: JsonSchemaNode | undefined;
+    for (const v of variants) {
+      if (v?.type === "null") nullable = true;
+      else if (!base) base = v;
+    }
+    const merged = { ...(base || {}), description: node.description ?? base?.description, title: node.title ?? base?.title };
+    return { type: typeof merged.type === "string" ? merged.type : undefined, nullable, node: merged };
+  }
+  if (Array.isArray(node.type)) {
+    const t = node.type.filter((x) => x !== "null");
+    return { type: t[0], nullable: node.type.includes("null"), node };
+  }
+  return { type: node.type, nullable: false, node };
+}
+
+/** snake_case / camelCase → "Title Case", with known acronyms upper-cased. */
+export function humanizeKey(key: string): string {
+  return key
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((w) =>
+      ACRONYMS.has(w.toLowerCase())
+        ? w.toUpperCase()
+        : w.charAt(0).toUpperCase() + w.slice(1),
+    )
+    .join(" ");
+}
+
+/** Derive a display unit from a field name, returning the de-suffixed base. */
+export function unitForField(key: string): { unit?: string; base: string } {
+  for (const { suffix, label } of UNIT_SUFFIXES) {
+    if (key.toLowerCase().endsWith(suffix)) {
+      return { unit: label, base: key.slice(0, key.length - suffix.length) };
+    }
+  }
+  return { base: key };
+}
+
+/** Human label for a field: schema `title` wins; else humanized (de-unit) key. */
+export function labelForField(key: string, node?: JsonSchemaNode): string {
+  if (node?.title && node.title.trim()) return node.title.trim();
+  const { base } = unitForField(key);
+  return humanizeKey(base);
+}
+
+export function isEmptyValue(v: unknown): boolean {
+  return (
+    v === null ||
+    v === undefined ||
+    (typeof v === "string" && v.trim() === "") ||
+    (Array.isArray(v) && v.length === 0)
+  );
+}
+
+export function classifyValue(v: unknown): FieldType {
+  if (isEmptyValue(v)) return "empty";
+  if (Array.isArray(v)) {
+    return v.some((x) => x && typeof x === "object" && !Array.isArray(x))
+      ? "objectArray"
+      : "scalarArray";
+  }
+  if (typeof v === "object") return "object";
+  return "scalar";
+}
+
+/** Body field order: schema property order first, then any data-only keys. */
+export function orderedKeys(
+  data: Record<string, unknown>,
+  schema?: JsonSchemaNode,
+): string[] {
+  const dataKeys = Object.keys(data).filter((k) => !INTERNAL_KEYS.has(k));
+  const props = schema?.properties;
+  if (!props) return dataKeys;
+  const schemaOrder = Object.keys(props).filter(
+    (k) => k in data && !INTERNAL_KEYS.has(k),
+  );
+  const extras = dataKeys.filter((k) => !schemaOrder.includes(k));
+  return [...schemaOrder, ...extras];
+}
+
+/** Union of column keys across table rows, schema order first. */
+export function tableColumns(
+  rows: Array<Record<string, unknown>>,
+  itemSchema?: JsonSchemaNode,
+): string[] {
+  const seen = new Set<string>();
+  const order: string[] = [];
+  const push = (k: string) => {
+    if (!seen.has(k) && !INTERNAL_KEYS.has(k)) {
+      seen.add(k);
+      order.push(k);
+    }
+  };
+  if (itemSchema?.properties) Object.keys(itemSchema.properties).forEach(push);
+  for (const r of rows) Object.keys(r || {}).forEach(push);
+  // Drop columns that are empty across every row — keeps tables readable.
+  return order.filter((k) => rows.some((r) => !isEmptyValue(r?.[k])));
+}
+
+// ── value formatting ────────────────────────────────────────────────
+const PROSE_KEYS = /(remarks|notes|description|analysis_notes|screening_notes|comment|summary)/i;
+
+export function isProseField(key: string, value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return PROSE_KEYS.test(key) || value.length > 120 || value.includes("\n");
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2})?/;
+
+export function formatScalar(key: string, value: unknown): string {
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") {
+    const { unit } = unitForField(key);
+    const num = Number.isInteger(value)
+      ? value.toLocaleString()
+      : // up to 6 dp for coords, trim trailing zeros otherwise
+        parseFloat(value.toFixed(6)).toLocaleString(undefined, {
+          maximumFractionDigits: 6,
+        });
+    return unit ? `${num} ${unit}` : num;
+  }
+  if (typeof value === "string") {
+    if (ISO_DATE.test(value)) {
+      const d = new Date(value);
+      if (!Number.isNaN(d.getTime())) {
+        return d.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        });
+      }
+    }
+    return value;
+  }
+  return String(value);
+}
+
+/**
+ * Schema descriptions are extraction-prompt text full of internal jargon
+ * ("GWSI C1 SITE_ID", "verbatim OCR", "Null only for EOB"). Never show that to
+ * end users. Strip leading codes; suppress anything still instruction-like.
+ */
+export function sanitizeDescription(desc?: string): string | undefined {
+  if (!desc) return undefined;
+  let s = desc.trim();
+  // Strip leading registry codes like "GWSI C1 SITE_ID." / "GWPD 11." / "GWSI C12 STATION_NAME —"
+  s = s.replace(/^(GW(SI|PD)\b[^.—]*[.—]\s*)+/i, "").trim();
+  if (/\b(OCR|verbatim|GWSI|GWPD|null only|regardless of|preserve|normaliz|extractor)\b/i.test(s)) {
+    return undefined;
+  }
+  return s.length >= 8 ? s : undefined;
+}

--- a/src/components/record/renderers.tsx
+++ b/src/components/record/renderers.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import React from "react";
+import { Tooltip } from "antd";
+import { descriptionForPath } from "@/lib/schemaDescriptions";
+import {
+  JsonSchemaNode,
+  classifyValue,
+  formatScalar,
+  humanizeKey,
+  isEmptyValue,
+  isProseField,
+  labelForField,
+  normalizeSchemaNode,
+  orderedKeys,
+  sanitizeDescription,
+  tableColumns,
+} from "./recordSchema";
+
+export interface RenderCtx {
+  descMap: Record<string, string>;
+}
+
+const childSchema = (
+  node: JsonSchemaNode | undefined,
+  key: string,
+): JsonSchemaNode | undefined => normalizeSchemaNode(node?.properties?.[key]).node;
+
+// ── Field label with optional plain-language helper ──────────────────
+function FieldLabel({
+  label,
+  path,
+  ctx,
+}: {
+  label: string;
+  path: Array<string | number>;
+  ctx: RenderCtx;
+}) {
+  const help = sanitizeDescription(descriptionForPath(path, ctx.descMap));
+  return (
+    <span className="inline-flex items-center gap-1 text-[13px] text-gray-500">
+      {label}
+      {help && (
+        <Tooltip title={help}>
+          <span className="cursor-help text-gray-300 text-[11px] leading-none">
+            ⓘ
+          </span>
+        </Tooltip>
+      )}
+    </span>
+  );
+}
+
+// ── A single scalar value, typed + humanized ─────────────────────────
+export function ScalarValue({
+  fieldKey,
+  value,
+  muted = "Not recorded",
+}: {
+  fieldKey: string;
+  value: unknown;
+  muted?: string;
+}) {
+  if (isEmptyValue(value)) {
+    return <span className="text-gray-300 italic">{muted}</span>;
+  }
+  if (typeof value === "boolean") {
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
+          value
+            ? "bg-green-50 text-green-700"
+            : "bg-gray-100 text-gray-500"
+        }`}
+      >
+        {value ? "Yes" : "No"}
+      </span>
+    );
+  }
+  return (
+    <span className="text-[13.5px] text-gray-900 tabular-nums">
+      {formatScalar(fieldKey, value)}
+    </span>
+  );
+}
+
+// ── Prose (remarks / long text) ──────────────────────────────────────
+function ProseBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[13px] text-gray-500 mb-1">{label}</div>
+      <p className="text-[13.5px] leading-relaxed text-gray-800 whitespace-pre-wrap">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+// ── Chip list (array of scalars) ─────────────────────────────────────
+export function ChipList({ values }: { values: unknown[] }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {values.map((v, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-[12px] text-gray-700"
+        >
+          {String(v)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ── Card shell ───────────────────────────────────────────────────────
+function Card({
+  title,
+  className = "",
+  children,
+}: {
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      className={`rounded-xl border border-gray-200 bg-white ${className}`}
+    >
+      {title && (
+        <header className="px-4 pt-3 pb-2 border-b border-gray-100">
+          <h3 className="text-[13px] font-semibold tracking-wide text-gray-700 uppercase">
+            {title}
+          </h3>
+        </header>
+      )}
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+// ── Attribute card: an object's scalar fields as label/value rows ────
+export function AttributeCard({
+  title,
+  data,
+  schema,
+  path,
+  ctx,
+}: {
+  title: string;
+  data: Record<string, unknown>;
+  schema?: JsonSchemaNode;
+  path: Array<string | number>;
+  ctx: RenderCtx;
+}) {
+  const keys = orderedKeys(data, schema);
+  const scalars = keys.filter((k) => {
+    const t = classifyValue(data[k]);
+    return (t === "scalar" || t === "empty") && !isProseField(k, data[k]);
+  });
+  const prose = keys.filter((k) => isProseField(k, data[k]));
+  const nestedObjects = keys.filter((k) => classifyValue(data[k]) === "object");
+  const nestedArrays = keys.filter((k) => {
+    const t = classifyValue(data[k]);
+    return t === "objectArray" || t === "scalarArray";
+  });
+
+  return (
+    <Card title={title}>
+      <div className="flex flex-col gap-3">
+        {scalars.length > 0 && (
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2.5">
+            {scalars.map((k) => (
+              <div key={k} className="flex flex-col gap-0.5 min-w-0">
+                <FieldLabel
+                  label={labelForField(k, childSchema(schema, k))}
+                  path={[...path, k]}
+                  ctx={ctx}
+                />
+                <dd className="m-0 break-words">
+                  <ScalarValue fieldKey={k} value={data[k]} />
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        {prose.map((k) => (
+          <ProseBlock
+            key={k}
+            label={labelForField(k, childSchema(schema, k))}
+            value={String(data[k])}
+          />
+        ))}
+
+        {nestedObjects.map((k) => (
+          <div key={k} className="rounded-lg bg-gray-50/70 p-3">
+            <div className="text-[12px] font-semibold text-gray-600 mb-2">
+              {labelForField(k, childSchema(schema, k))}
+            </div>
+            <NestedObject
+              data={data[k] as Record<string, unknown>}
+              schema={childSchema(schema, k)}
+              path={[...path, k]}
+              ctx={ctx}
+            />
+          </div>
+        ))}
+
+        {nestedArrays.map((k) => (
+          <FieldBlock
+            key={k}
+            fieldKey={k}
+            value={data[k]}
+            schema={childSchema(schema, k)}
+            path={[...path, k]}
+            ctx={ctx}
+          />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// Nested object inside a card — flat label/value grid, no extra chrome.
+function NestedObject({
+  data,
+  schema,
+  path,
+  ctx,
+}: {
+  data: Record<string, unknown>;
+  schema?: JsonSchemaNode;
+  path: Array<string | number>;
+  ctx: RenderCtx;
+}) {
+  const keys = orderedKeys(data, schema);
+  return (
+    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+      {keys.map((k) => (
+        <div key={k} className="flex flex-col gap-0.5 min-w-0">
+          <FieldLabel
+            label={labelForField(k, childSchema(schema, k))}
+            path={[...path, k]}
+            ctx={ctx}
+          />
+          <dd className="m-0 break-words">
+            {classifyValue(data[k]) === "scalarArray" ? (
+              <ChipList values={data[k] as unknown[]} />
+            ) : (
+              <ScalarValue fieldKey={k} value={data[k]} />
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+// ── Record table: array of objects ───────────────────────────────────
+export function RecordTable({
+  title,
+  rows,
+  itemSchema,
+  path,
+  ctx,
+}: {
+  title: string;
+  rows: Array<Record<string, unknown>>;
+  itemSchema?: JsonSchemaNode;
+  path: Array<string | number>;
+  ctx: RenderCtx;
+}) {
+  const cols = tableColumns(rows, itemSchema);
+  const isNumeric = (k: string) =>
+    rows.some((r) => typeof r?.[k] === "number");
+
+  return (
+    <Card title={`${title} · ${rows.length}`} className="overflow-hidden">
+      <div className="overflow-x-auto -mx-4 -mb-4">
+        <table className="min-w-full text-[13px] border-collapse">
+          <thead>
+            <tr className="border-b border-gray-200">
+              {cols.map((k) => (
+                <th
+                  key={k}
+                  className={`px-3 py-2 font-medium text-gray-500 whitespace-nowrap ${
+                    isNumeric(k) ? "text-right" : "text-left"
+                  }`}
+                >
+                  <Tooltip
+                    title={sanitizeDescription(
+                      descriptionForPath([...path, k], ctx.descMap),
+                    )}
+                  >
+                    {labelForField(k, childSchema(itemSchema, k))}
+                  </Tooltip>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr
+                key={i}
+                className="border-b border-gray-100 last:border-0 hover:bg-gray-50/60"
+              >
+                {cols.map((k) => (
+                  <td
+                    key={k}
+                    className={`px-3 py-2 align-top ${
+                      isNumeric(k)
+                        ? "text-right tabular-nums whitespace-nowrap"
+                        : "text-left"
+                    }`}
+                  >
+                    {isEmptyValue(r?.[k]) ? (
+                      <span className="text-gray-300">—</span>
+                    ) : classifyValue(r?.[k]) === "scalarArray" ? (
+                      <ChipList values={r[k] as unknown[]} />
+                    ) : typeof r?.[k] === "object" ? (
+                      <span className="text-gray-400 italic">(details)</span>
+                    ) : (
+                      <ScalarValue
+                        fieldKey={k}
+                        value={r?.[k]}
+                        muted="—"
+                      />
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+// ── Dispatch for one top-level (or nested-array) field ───────────────
+export function FieldBlock({
+  fieldKey,
+  value,
+  schema,
+  path,
+  ctx,
+}: {
+  fieldKey: string;
+  value: unknown;
+  schema?: JsonSchemaNode;
+  path: Array<string | number>;
+  ctx: RenderCtx;
+}) {
+  const label = labelForField(fieldKey, schema);
+  const type = classifyValue(value);
+
+  if (type === "object") {
+    return (
+      <AttributeCard
+        title={label}
+        data={value as Record<string, unknown>}
+        schema={schema}
+        path={path}
+        ctx={ctx}
+      />
+    );
+  }
+  if (type === "objectArray") {
+    return (
+      <RecordTable
+        title={label}
+        rows={value as Array<Record<string, unknown>>}
+        itemSchema={normalizeSchemaNode(schema?.items).node}
+        path={path}
+        ctx={ctx}
+      />
+    );
+  }
+  if (type === "scalarArray") {
+    return (
+      <Card title={label}>
+        <ChipList values={value as unknown[]} />
+      </Card>
+    );
+  }
+  // empty array/object/scalar at top level
+  return (
+    <Card title={label}>
+      <span className="text-gray-300 italic text-[13.5px]">
+        {humanizeKey(fieldKey)} — Not recorded
+      </span>
+    </Card>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -520,6 +520,7 @@ export interface PreviewDataTable {
 }
 
 export interface PreviewJobFile {
+    /** Unique row id — the record's section_result_id (or a synthetic fallback). */
     id: string;
     filename: string;
     result: any;
@@ -528,6 +529,11 @@ export interface PreviewJobFile {
     job_name: string;
     admin_verified?: boolean;
     review_status?: 'pending' | 'in_review' | 'reviewed' | 'approved' | 'rejected';
+    /** V2: the originating file id (multiple records can share one file). */
+    file_id?: string;
+    /** V2: the record's document type. */
+    slug?: string | null;
+    section_result_id?: string | null;
 }
 
 export interface PreviewAnalyticsReport {
@@ -1384,10 +1390,12 @@ class ApiClient {
         id: string,
         page: number = 1,
         pageSize: number = 20,
-        search?: string
+        search?: string,
+        opts?: { slug?: string | null; fileId?: string | null }
     ): Promise<ApiResponse<{
         preview: PreviewDataTable;
         jobFiles: PreviewJobFile[];
+        slugs?: Array<{ slug: string | null; count: number }>;
         pagination: {
             total: number;
             page: number;
@@ -1402,7 +1410,38 @@ class ApiClient {
         if (search && search.trim()) {
             params.append('search', search.trim());
         }
+        if (opts?.slug) params.append('slug', opts.slug);
+        if (opts?.fileId) params.append('fileId', opts.fileId);
         return this.request(`/previews/${id}/data?${params.toString()}`);
+    }
+
+    /** "By file" lens: files with a by-type record summary + review status. */
+    async getPreviewFiles(
+        id: string,
+        page: number = 1,
+        pageSize: number = 20,
+        search?: string
+    ): Promise<ApiResponse<{
+        preview: PreviewDataTable;
+        files: Array<{
+            id: string;
+            filename: string;
+            job_name: string;
+            created_at: string;
+            processing_status: string;
+            admin_verified?: boolean;
+            review_status?: string;
+            total_records: number;
+            by_type: Array<{ slug: string | null; count: number }>;
+        }>;
+        pagination: { total: number; page: number; pageSize: number; totalPages: number };
+    }>> {
+        const params = new URLSearchParams({
+            page: page.toString(),
+            pageSize: pageSize.toString(),
+        });
+        if (search && search.trim()) params.append('search', search.trim());
+        return this.request(`/previews/${id}/files?${params.toString()}`);
     }
 
     async getPreviewStatistics(id: string): Promise<ApiResponse<{


### PR DESCRIPTION
The customer-facing record viewer for V2 (multi-record) previews, plus a navigation rail that replaces document-type tabs.

⚠️ **Runtime-depends on backend PR text-to-structured-data#39** (the record-list / by-file endpoints). Merge/deploy that **first**.

## RecordView engine — `src/components/record/`
A schema-driven, **customer-facing** record renderer (no raw keys/JSON, plain language for non-technical users):
- **Trust header** — confidence / QA / verification chips, identity from the record.
- **Hero slot** + 3 heroes via a slug registry: `mgs_well_log` (wraps the existing `WellboreDiagram`), `borehole_log` (lithology depth column), `aquifer_test` (drawdown/recovery chart, chart.js).
- **Generic body** — attribute cards + dense tables, units (`12 ft`), Yes/No, "Not recorded" for missing, and a **data-driven fallback** when no schema.

## Preview page
- **`PreviewRail`** — collapsible left rail (persisted in localStorage, `w-56 ↔ w-12`, mirrors `JobJobsRail`): **All records / Files / one entry per document type** with counts. Replaces tabs.
- Reads **record-rows** from the V2 backend; **by-file lens** (filename + by-type summary + status) with **drill into a file**; rows open a **RecordView drawer**.
- Drawer reuses the preview's **public** schema (no authed fetch) so anonymous preview viewers aren't bounced to login (bug found + fixed during E2E).
- **`page` / `per_page` / `slug` / `view`** persisted in the URL (`previewUrlState`, mirrors `jobViewUrlState`) — shareable links.

## Verification
Verified **end-to-end in the browser** against the SQL backend: rail + type filter, record + file pagination, file drill-in, URL persistence, collapse, and the wellbore hero rendering for a V1 record. `tsc` clean.

Dev-only harness route + launch configs were intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)