### PR TITLE
Add "Export for GIS" to the preview by-type view

### DIFF
--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import React, { useState, useEffect, useMemo, useCallback } from "react";
-import { useParams, useRouter, usePathname, useSearchParams } from "next/navigation";
+import {
+  useParams,
+  useRouter,
+  usePathname,
+  useSearchParams,
+} from "next/navigation";
 import { apiClient, PreviewDataTable, PreviewJobFile } from "@/lib/api";
 import {
   getCachedPreviewData,
@@ -23,11 +28,7 @@ import {
 } from "antd";
 import { RecordView } from "@/components/record/RecordView";
 import { humanizeKey } from "@/components/record/recordSchema";
-import {
-  PreviewRail,
-  PreviewView,
-  documentTypeLabel,
-} from "./PreviewRail";
+import { PreviewRail, PreviewView, documentTypeLabel } from "./PreviewRail";
 import { parsePreviewUrl, buildPreviewParams } from "./previewUrlState";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
 import {
@@ -685,8 +686,7 @@ const PreviewPage: React.FC = () => {
         const slugFilter = view.kind === "records" ? view.slug : undefined;
         const fileFilter = view.kind === "file" ? view.fileId : undefined;
         // Only the unfiltered "all records" view uses the page cache.
-        const useCache =
-          !forceRefresh && view.kind === "records" && !view.slug;
+        const useCache = !forceRefresh && view.kind === "records" && !view.slug;
 
         if (useCache) {
           const cached = getCachedPreviewData(
@@ -910,6 +910,24 @@ const PreviewPage: React.FC = () => {
     }
 
     return String(obj);
+  };
+
+  // GIS-ready CSV: all records of the selected type (not just this page),
+  // flattened to a clean attribute table server-side. Streams the download.
+  const gisExportSlug =
+    view.kind === "records" && view.slug && view.slug !== "untyped"
+      ? view.slug
+      : null;
+
+  const handleGisExport = () => {
+    if (!gisExportSlug) return;
+    const url = apiClient.getPreviewGisExportUrl(previewId, gisExportSlug);
+    const a = document.createElement("a");
+    a.href = url;
+    a.rel = "noopener";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
   };
 
   const handleExport = (format: "csv" | "json") => {
@@ -1161,15 +1179,28 @@ const PreviewPage: React.FC = () => {
             <Dropdown
               menu={{
                 items: [
+                  ...(gisExportSlug
+                    ? [
+                        {
+                          key: "gis",
+                          label: `Export for GIS — ${documentTypeLabel(
+                            gisExportSlug,
+                          )} (CSV)`,
+                          icon: <DownloadOutlined />,
+                          onClick: handleGisExport,
+                        },
+                        { type: "divider" as const },
+                      ]
+                    : []),
                   {
                     key: "csv",
-                    label: "Export as CSV",
+                    label: "Export as CSV (this page)",
                     icon: <DownloadOutlined />,
                     onClick: () => handleExport("csv"),
                   },
                   {
                     key: "json",
-                    label: "Export as JSON",
+                    label: "Export as JSON (this page)",
                     icon: <DownloadOutlined />,
                     onClick: () => handleExport("json"),
                   },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1444,6 +1444,16 @@ class ApiClient {
         return this.request(`/previews/${id}/files?${params.toString()}`);
     }
 
+    /**
+     * Direct URL for the GIS-ready CSV export of one document type across a
+     * preview (all records of that type). Use as an anchor href to stream the
+     * download; the endpoint is unauthenticated like the other preview reads.
+     */
+    getPreviewGisExportUrl(id: string, slug: string): string {
+        const params = new URLSearchParams({ slug, format: "csv" });
+        return `${this.baseURL}/previews/${id}/export?${params.toString()}`;
+    }
+
     async getPreviewStatistics(id: string): Promise<ApiResponse<{
         total: number;
         humanVerified: number;


### PR DESCRIPTION
## What
When a specific document type is selected in the preview rail, the export dropdown gains **"Export for GIS — &lt;Type&gt; (CSV)"**. It downloads the flat, GIS-ready attribute table for **all** records of that type (not just the current page) from the new backend export endpoint. Existing generic CSV/JSON exports are kept, relabeled **"(this page)"** to distinguish them.

## Changes
- `api.ts`: `getPreviewGisExportUrl(id, slug)` builds the streamed download URL.
- `page.tsx`: `gisExportSlug` (the active type; excludes "all records" and "untyped"), `handleGisExport()` triggers a cross-origin anchor navigation so the backend's `Content-Disposition` drives the named download; the dropdown item renders only when a type is selected.

## Verification (E2E, web :3001 → backend :3000, live DB)
- Selecting **Boring Logs** sets `?slug=borehole_log`
- Dropdown shows **"Export for GIS — Boring Logs (CSV)"** alongside the page-scoped exports
- Clicking it hits `…/previews/:id/export?slug=borehole_log&format=csv` → `200 text/csv`, `well_id`-first header, 115 records
- No console errors; `tsc` clean for changed files

## Coupling / merge order
Requires the backend export endpoint — **text-to-structured-data#40** (merge that first). Stacked on **`feat/preview-rail-record-viewer`** (this PR's base), which provides the by-type rail this button hangs off.

## Scope
Phase 1 (attribute-table export) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)