### PR TITLE
feat: keyboard shortcuts to move between sections in file viewer

### DIFF
--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -1081,6 +1081,7 @@ const FileTable: React.FC<FileTableProps> = ({
     if (!fullscreenModalOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey) return;
       if (e.key === "ArrowLeft" && fullscreenFileIndex > 0) {
         onActiveFileIdChange?.(data[fullscreenFileIndex - 1].id);
       } else if (

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -641,6 +641,42 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
     [sectionEntries, onSelectedSectionResultIdChange],
   );
 
+  useEffect(() => {
+    if (sectionEntries.length <= 1) return;
+
+    const isTypingTarget = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false;
+      const tag = target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+        return true;
+      }
+      if (target.isContentEditable) return true;
+      if (target.closest(".cm-editor")) return true;
+      if (target.closest(".ant-select-dropdown")) return true;
+      return false;
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      if (isTypingTarget(e.target)) return;
+
+      if (e.key === "ArrowLeft" && selectedSectionIdx > 0) {
+        e.preventDefault();
+        selectSectionIdx(selectedSectionIdx - 1);
+      } else if (
+        e.key === "ArrowRight" &&
+        selectedSectionIdx < sectionEntries.length - 1
+      ) {
+        e.preventDefault();
+        selectSectionIdx(selectedSectionIdx + 1);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [sectionEntries.length, selectedSectionIdx, selectSectionIdx]);
+
   const setResultTab = useCallback(
     (tab: TabType) => {
       setFallbackTab(tab);
@@ -1397,7 +1433,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
               selectSectionIdx(Math.max(0, selectedSectionIdx - 1))
             }
             className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            title="Previous section"
+            title="Previous section (⌘←)"
           >
             <ChevronLeft className="w-4 h-4 text-gray-600" />
           </button>
@@ -1454,7 +1490,7 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
               )
             }
             className="p-0.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            title="Next section"
+            title="Next section (⌘→)"
           >
             <ChevronRight className="w-4 h-4 text-gray-600" />
           </button>


### PR DESCRIPTION
## Summary
- Add **⌘← / ⌘→** (Ctrl on Windows/Linux) to move between sections in the results viewer, matching the existing section chevron controls.
- Ignore the shortcut while typing in inputs, the JSON code editor, or an open section dropdown.
- Update file-modal **← / →** navigation to skip when ⌘/Ctrl is held so file and section shortcuts do not conflict.
- Show keyboard hints on the section prev/next button tooltips.

## Test plan
- [x] Open a job file in the fullscreen modal with multiple sections (v2 envelope).
- [x] On the Results pane, press ⌘← / ⌘→ and confirm the section picker changes.
- [x] Press ← / → without modifier and confirm it still moves between files.
- [x] Focus the JSON code editor or a comment input and confirm ⌘← / ⌘→ do not change sections.
- [x] Open a file with only one section and confirm ⌘← / ⌘→ have no effect.


Made with [Cursor](https://cursor.com)