### PR TITLE
Fix file-viewer resize glitch and make findings panel resizable

### DIFF
--- a/src/components/file/FileViewerLayout.tsx
+++ b/src/components/file/FileViewerLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import { Typography } from "antd";
+import React from "react";
+import { Splitter, Typography } from "antd";
 import { ExclamationCircleOutlined } from "@ant-design/icons";
 import type { JobFile } from "@/lib/api";
 import type { ViewerPane, ViewerResultTab } from "@/lib/jobViewUrlState";
@@ -61,59 +61,6 @@ export default function FileViewerLayout({
   onViewerResultTabChange,
   ...headerProps
 }: FileViewerLayoutProps) {
-  const [splitPosition, setSplitPosition] = useState(50);
-  const [isResizing, setIsResizing] = useState(false);
-  const splitPositionRef = useRef(50);
-  const leftPaneRef = useRef<HTMLDivElement>(null);
-  const rightPaneRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    splitPositionRef.current = splitPosition;
-  }, [splitPosition]);
-
-  useEffect(() => {
-    let animationFrameId: number | null = null;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!isResizing) return;
-      if (animationFrameId) cancelAnimationFrame(animationFrameId);
-
-      animationFrameId = requestAnimationFrame(() => {
-        const container = document.querySelector(`.${splitContainerClassName}`);
-        if (!container || !leftPaneRef.current || !rightPaneRef.current) return;
-
-        const rect = container.getBoundingClientRect();
-        const newPosition = ((e.clientX - rect.left) / rect.width) * 100;
-        const clamped = Math.max(20, Math.min(80, newPosition));
-        splitPositionRef.current = clamped;
-        leftPaneRef.current.style.width = `${clamped}%`;
-        rightPaneRef.current.style.width = `${100 - clamped}%`;
-      });
-    };
-
-    const handleMouseUp = () => {
-      setSplitPosition(splitPositionRef.current);
-      setIsResizing(false);
-    };
-
-    if (isResizing) {
-      document.addEventListener("mousemove", handleMouseMove, {
-        passive: true,
-      });
-      document.addEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-    }
-
-    return () => {
-      if (animationFrameId) cancelAnimationFrame(animationFrameId);
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [isResizing, splitContainerClassName]);
-
   const _pageCountDisplay = React.useMemo(() => {
     if (!file) return null;
     if (
@@ -131,11 +78,6 @@ export default function FileViewerLayout({
     return null;
   }, [file]);
 
-  const handleMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsResizing(true);
-  };
-
   return (
     <div className={`flex flex-col overflow-hidden bg-gray-50 ${className}`}>
       <FileViewerHeader file={file} {...headerProps} />
@@ -149,71 +91,61 @@ export default function FileViewerLayout({
           </div>
         )}
 
-        <div
-          ref={leftPaneRef}
-          className="flex flex-col min-w-0 overflow-hidden border-r border-gray-200 bg-gray-100"
-          style={{ width: `${splitPosition}%`, minWidth: "200px" }}
-        >
-          <div className="px-3 py-1 bg-white border-b border-gray-200 flex-shrink-0 flex items-baseline gap-2">
-            <Text className="text-xs font-medium text-gray-600">PDF</Text>
-            {_pageCountDisplay != null && (
-              <Text className="text-[11px] text-gray-400">
-                {_pageCountDisplay} pages
-              </Text>
-            )}
-          </div>
-          <div className="flex-1 overflow-hidden min-h-0">
-            {pdfUrlLoading ? (
-              <div className="flex items-center justify-center h-full">
-                <Loader className="w-6 h-6 animate-spin text-gray-400" />
+        <Splitter className="flex-1 min-h-0">
+          <Splitter.Panel defaultSize="50%" min={200}>
+            <div className="flex flex-col h-full min-w-0 overflow-hidden border-r border-gray-200 bg-gray-100">
+              <div className="px-3 py-1 bg-white border-b border-gray-200 flex-shrink-0 flex items-baseline gap-2">
+                <Text className="text-xs font-medium text-gray-600">PDF</Text>
+                {_pageCountDisplay != null && (
+                  <Text className="text-[11px] text-gray-400">
+                    {_pageCountDisplay} pages
+                  </Text>
+                )}
               </div>
-            ) : pdfUrl ? (
-              <iframe
-                key={file.id}
-                src={pdfUrl}
-                className="w-full h-full border-0 bg-white"
-                title={`PDF viewer for ${file.filename}`}
+              <div className="flex-1 overflow-hidden min-h-0">
+                {pdfUrlLoading ? (
+                  <div className="flex items-center justify-center h-full">
+                    <Loader className="w-6 h-6 animate-spin text-gray-400" />
+                  </div>
+                ) : pdfUrl ? (
+                  <iframe
+                    key={file.id}
+                    src={pdfUrl}
+                    className="w-full h-full border-0 bg-white"
+                    title={`PDF viewer for ${file.filename}`}
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-full">
+                    <Text type="secondary" className="text-sm">
+                      <ExclamationCircleOutlined className="mr-2" />
+                      Unable to load PDF
+                    </Text>
+                  </div>
+                )}
+              </div>
+            </div>
+          </Splitter.Panel>
+
+          <Splitter.Panel min={280}>
+            <div className="flex flex-col h-full min-w-0 overflow-hidden bg-white">
+              <FileViewerRightPane
+                file={file}
+                jobSchema={jobSchema}
+                editable={editable}
+                comments={comments}
+                onAddComment={onAddComment}
+                onUpdate={onUpdate}
+                onSectionsUpdated={onSectionsUpdated}
+                viewerPane={viewerPane}
+                onViewerPaneChange={onViewerPaneChange}
+                viewerSectionId={viewerSectionId}
+                onViewerSectionChange={onViewerSectionChange}
+                viewerResultTab={viewerResultTab}
+                onViewerResultTabChange={onViewerResultTabChange}
               />
-            ) : (
-              <div className="flex items-center justify-center h-full">
-                <Text type="secondary" className="text-sm">
-                  <ExclamationCircleOutlined className="mr-2" />
-                  Unable to load PDF
-                </Text>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div
-          className="w-1 bg-gray-200 hover:bg-gray-400 cursor-col-resize flex-shrink-0"
-          style={{ minWidth: "4px" }}
-          onMouseDown={handleMouseDown}
-          role="separator"
-          aria-orientation="vertical"
-        />
-
-        <div
-          ref={rightPaneRef}
-          className="flex flex-col min-w-0 overflow-hidden bg-white"
-          style={{ width: `${100 - splitPosition}%`, minWidth: "280px" }}
-        >
-          <FileViewerRightPane
-            file={file}
-            jobSchema={jobSchema}
-            editable={editable}
-            comments={comments}
-            onAddComment={onAddComment}
-            onUpdate={onUpdate}
-            onSectionsUpdated={onSectionsUpdated}
-            viewerPane={viewerPane}
-            onViewerPaneChange={onViewerPaneChange}
-            viewerSectionId={viewerSectionId}
-            onViewerSectionChange={onViewerSectionChange}
-            viewerResultTab={viewerResultTab}
-            onViewerResultTabChange={onViewerResultTabChange}
-          />
-        </div>
+            </div>
+          </Splitter.Panel>
+        </Splitter>
       </div>
     </div>
   );

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -28,6 +28,7 @@ import {
   Modal,
   Popconfirm,
   Select,
+  Splitter,
   Typography,
 } from "antd";
 import type { MenuProps } from "antd";
@@ -401,7 +402,7 @@ function QAFindingsPanel({
   };
 
   return (
-    <div className="flex-shrink-0 border-t border-gray-200 bg-white px-3 py-2 space-y-2 max-h-64 overflow-y-auto">
+    <div className="h-full bg-white px-3 py-2 space-y-2 overflow-y-auto">
       <div className="flex items-center justify-between">
         <span className="text-xs font-semibold text-gray-600 uppercase tracking-wide">
           QA Findings{" "}
@@ -1414,6 +1415,61 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
     }
   };
 
+  // QA findings render below the JSON result, in a resizable bottom panel.
+  const showFindings =
+    isV2 &&
+    !!selectedSection?.sectionResultId &&
+    selectedSectionFindings.length > 0;
+
+  const jsonViewerEl = (
+    <JsonViewer
+      text={editableJson}
+      descriptions={fieldDescriptions}
+      onChange={({ text, isValid, error }) => {
+        setEditableJson(text);
+        setJsonError(isValid ? null : (error ?? "Invalid JSON"));
+      }}
+      readOnly={!editable}
+      bordered={false}
+      defaultMode="tree"
+      height="100%"
+      toolbar={
+        editable
+          ? [
+              "mode",
+              "format",
+              "minify",
+              "wrap",
+              "search",
+              "copy",
+              "download",
+              "upload",
+              "cancel",
+              "save",
+            ]
+          : ["mode", "wrap", "search", "copy", "download"]
+      }
+      onSave={
+        editable
+          ? async () => {
+              await handleSave();
+            }
+          : undefined
+      }
+      onCancel={
+        editable
+          ? () => {
+              setEditableJson(JSON.stringify(sectionData, null, 2));
+              setJsonError(null);
+            }
+          : undefined
+      }
+      cancelLabel="Reset"
+      saveLabel={saveLabel}
+      saving={isSaving}
+    />
+  );
+
   return (
     <div
       className={`bg-white flex flex-col h-full overflow-hidden ${className}`}
@@ -1655,69 +1711,28 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
           transition={{ duration: 0.2 }}
           className="flex-1 overflow-hidden flex flex-col min-h-0"
         >
-          {activeTab === "results" && (
-            <div className="flex-1 min-h-0 flex flex-col">
-              <JsonViewer
-                text={editableJson}
-                descriptions={fieldDescriptions}
-                onChange={({ text, isValid, error }) => {
-                  setEditableJson(text);
-                  setJsonError(isValid ? null : (error ?? "Invalid JSON"));
-                }}
-                readOnly={!editable}
-                bordered={false}
-                defaultMode="tree"
-                height="100%"
-                toolbar={
-                  editable
-                    ? [
-                        "mode",
-                        "format",
-                        "minify",
-                        "wrap",
-                        "search",
-                        "copy",
-                        "download",
-                        "upload",
-                        "cancel",
-                        "save",
-                      ]
-                    : ["mode", "wrap", "search", "copy", "download"]
-                }
-                onSave={
-                  editable
-                    ? async () => {
-                        await handleSave();
-                      }
-                    : undefined
-                }
-                onCancel={
-                  editable
-                    ? () => {
-                        setEditableJson(JSON.stringify(sectionData, null, 2));
-                        setJsonError(null);
-                      }
-                    : undefined
-                }
-                cancelLabel="Reset"
-                saveLabel={saveLabel}
-                saving={isSaving}
-              />
-            </div>
-          )}
-
-          {/* QA Findings Panel — shown below the JSON editor when section is selected */}
           {activeTab === "results" &&
-            isV2 &&
-            selectedSection?.sectionResultId &&
-            selectedSectionFindings.length > 0 && (
-              <QAFindingsPanel
-                findings={selectedSectionFindings}
-                onUpdate={handleUpdateFinding}
-                onApply={handleApplyFinding}
-                canApply={editable}
-              />
-            )}
+            (showFindings ? (
+              // JSON result on top, QA findings below — the divider between them
+              // is draggable so the user can grow either pane.
+              <Splitter layout="vertical" className="flex-1 min-h-0">
+                <Splitter.Panel min={120}>
+                  <div className="h-full min-h-0 flex flex-col">
+                    {jsonViewerEl}
+                  </div>
+                </Splitter.Panel>
+                <Splitter.Panel defaultSize={220} min={80} max="70%">
+                  <QAFindingsPanel
+                    findings={selectedSectionFindings}
+                    onUpdate={handleUpdateFinding}
+                    onApply={handleApplyFinding}
+                    canApply={editable}
+                  />
+                </Splitter.Panel>
+              </Splitter>
+            ) : (
+              <div className="flex-1 min-h-0 flex flex-col">{jsonViewerEl}</div>
+            ))}
 
           {activeTab === "markdown" && markdown && (
             <div className="flex-1 flex flex-col overflow-hidden min-h-0">


### PR DESCRIPTION
## The bug

In the dashboard file modal, the **PDF (left) ↔ Result (right)** split would glitch while dragging — the panes froze mid-drag, and the splitter stuck to the cursor even after releasing the mouse.

**Root cause:** the resize was driven by `mousemove`/`mouseup` listeners on the top-level `document`. The PDF pane is an `<iframe>` — a separate browsing context. As soon as the cursor crossed into the iframe during a drag, the iframe swallowed the mouse events: `mousemove` stopped reaching the handler (pane freezes), and the `mouseup` over the iframe never reached the parent, so `isResizing` stayed `true` and the splitter kept following the cursor.

## The fix (standard, not a patch)

Replaced the hand-rolled resize machinery (`splitPosition`/`isResizing` state, document listeners, `requestAnimationFrame` loop, `querySelector`, manual `.style.width` writes) with antd's **`Splitter`** component (antd 5.27 is already a dependency). `Splitter` renders a transparent drag mask over the panels during resize, so the iframe can no longer capture pointer events — the glitch disappears structurally. Same min/default sizes preserved (left `50%` / `min 200`, right `min 280`).

## Also: findings panel is now resizable

The QA findings block under the result JSON was a fixed `max-h-64` panel. It's now the bottom panel of a **vertical `Splitter`** (JSON result on top, findings below with a draggable divider). When there are no findings, the JSON viewer renders alone, unchanged.

## Verification
- `tsc` and ESLint clean on the changed code; app compiles and renders with no console/build errors.
- Interactive drag confirmed working by the author in the live modal (PDF/Result no longer glitches; findings resizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)