### PR TITLE
Phase 2 UI: Processing Services panel (run geocoding/enrichment)

### DIFF
--- a/src/app/preview/[id]/ServicesDrawer.tsx
+++ b/src/app/preview/[id]/ServicesDrawer.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Drawer, Button as AntButton, Spin, Tag, notification } from "antd";
+import { apiClient, RunServiceResult } from "@/lib/api";
+import { documentTypeLabel } from "./PreviewRail";
+
+// Plain-English copy for the registered services.
+const SERVICE_META: Record<string, { title: string; desc: string }> = {
+  geocode_locations: {
+    title: "Geocode locations",
+    desc: "Derive a coordinate + precision tier for each record — from document coordinates, a street address (Google), or the PLSS section (Michigan Wellogic). Writes to the spatial layer; the extracted record is never changed.",
+  },
+  mgs_enrich: {
+    title: "Enrich with MGS",
+    desc: "Merge Michigan MGS permit data into records that carry a permit number.",
+  },
+};
+
+const tierColor: Record<string, string> = {
+  exact: "green",
+  good: "cyan",
+  plss_centroid: "gold",
+  approx: "orange",
+  unresolved: "default",
+};
+
+function ServiceResultView({ result }: { result: RunServiceResult }) {
+  const svc = Object.values(result.summary)[0] || { applied: 0, skipped: 0, error: 0 };
+  return (
+    <div className="mt-2 rounded-md bg-gray-50 p-2 text-sm">
+      <div className="text-gray-700">
+        {result.apply ? "Applied" : "Dry-run"} · {result.recordsMatched} records
+        {result.apply ? ` · ${result.filesUpdated} files updated` : ""}
+      </div>
+      <div className="mt-1 flex flex-wrap gap-1">
+        <Tag color="green">applied {svc.applied}</Tag>
+        <Tag>skipped {svc.skipped}</Tag>
+        {svc.error > 0 && <Tag color="red">error {svc.error}</Tag>}
+      </div>
+      {result.precisionTiers && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {Object.entries(result.precisionTiers).map(([tier, n]) => (
+            <Tag key={tier} color={tierColor[tier] || "default"}>
+              {tier} {n}
+            </Tag>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ServicesDrawer({
+  previewId,
+  slug,
+  open,
+  onClose,
+  onApplied,
+}: {
+  previewId: string;
+  slug: string | null;
+  open: boolean;
+  onClose: () => void;
+  onApplied?: () => void;
+}) {
+  const [services, setServices] = useState<{ name: string; version: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [results, setResults] = useState<Record<string, RunServiceResult>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await apiClient.getProcessingServices();
+      if (r.success) setServices(r.data?.services || []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      load();
+      setResults({});
+    }
+  }, [open, load]);
+
+  const run = async (name: string, apply: boolean) => {
+    if (!slug) return;
+    setBusy(`${name}:${apply}`);
+    try {
+      const r = await apiClient.runPreviewService(previewId, { name, slug, apply });
+      if (r.success && r.data) {
+        setResults((p) => ({ ...p, [name]: r.data! }));
+        if (apply) {
+          notification.success({
+            message: `${SERVICE_META[name]?.title || name} applied`,
+            description: `${r.data.recordsMatched} records processed.`,
+          });
+          onApplied?.();
+        }
+      } else {
+        notification.error({ message: "Service failed", description: r.message });
+      }
+    } catch (e: any) {
+      notification.error({ message: "Service failed", description: e?.message });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Drawer
+      title="Processing services"
+      placement="right"
+      width={460}
+      open={open}
+      onClose={onClose}
+    >
+      {!slug && (
+        <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          Select a document type in the left rail — services run over all records
+          of one type.
+        </div>
+      )}
+      {loading ? (
+        <div className="flex justify-center py-8">
+          <Spin />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {services.map((s) => {
+            const meta = SERVICE_META[s.name] || { title: s.name, desc: "" };
+            return (
+              <div key={s.name} className="rounded-lg border border-gray-200 p-3">
+                <div className="font-medium text-gray-900">{meta.title}</div>
+                <div className="mt-1 text-sm text-gray-500">{meta.desc}</div>
+                <div className="mt-3 flex gap-2">
+                  <AntButton
+                    size="small"
+                    disabled={!slug || busy !== null}
+                    loading={busy === `${s.name}:false`}
+                    onClick={() => run(s.name, false)}
+                  >
+                    Preview (dry-run)
+                  </AntButton>
+                  <AntButton
+                    size="small"
+                    type="primary"
+                    disabled={!slug || busy !== null}
+                    loading={busy === `${s.name}:true`}
+                    onClick={() => run(s.name, true)}
+                  >
+                    Apply{slug ? ` to ${documentTypeLabel(slug)}` : ""}
+                  </AntButton>
+                </div>
+                {results[s.name] && <ServiceResultView result={results[s.name]} />}
+              </div>
+            );
+          })}
+          {services.length === 0 && (
+            <div className="text-sm text-gray-500">No services registered.</div>
+          )}
+        </div>
+      )}
+    </Drawer>
+  );
+}

--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
 import { RecordView } from "@/components/record/RecordView";
 import { humanizeKey } from "@/components/record/recordSchema";
 import { PreviewRail, PreviewView, documentTypeLabel } from "./PreviewRail";
+import { ServicesDrawer } from "./ServicesDrawer";
 import { parsePreviewUrl, buildPreviewParams } from "./previewUrlState";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
 import {
@@ -466,6 +467,7 @@ const PreviewPage: React.FC = () => {
   // data-driven fallback + slug-based hero handle the rest.
   const [recordDrawer, setRecordDrawer] = useState<any>(null);
   const [exportDrawerOpen, setExportDrawerOpen] = useState(false);
+  const [servicesDrawerOpen, setServicesDrawerOpen] = useState(false);
 
   useEffect(() => {
     document.title = previewData?.preview.name ?? "Preview";
@@ -1293,6 +1295,13 @@ const PreviewPage: React.FC = () => {
             />
 
             <AntButton
+              title="Run processing services (geocoding, enrichment)"
+              onClick={() => setServicesDrawerOpen(true)}
+            >
+              Services
+            </AntButton>
+
+            <AntButton
               icon={<DownloadOutlined />}
               title="Download / export"
               onClick={() => setExportDrawerOpen(true)}
@@ -1361,6 +1370,14 @@ const PreviewPage: React.FC = () => {
                 />
               </div>
             </Drawer>
+
+            <ServicesDrawer
+              previewId={previewId}
+              slug={gisExportSlug}
+              open={servicesDrawerOpen}
+              onClose={() => setServicesDrawerOpen(false)}
+              onApplied={handleRefresh}
+            />
 
             <AntButton
               icon={<ReloadOutlined />}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -519,6 +519,18 @@ export interface PreviewDataTable {
     item_count?: number;
 }
 
+/** Result of POST /previews/:id/run-service (dry-run or apply). */
+export interface RunServiceResult {
+    apply: boolean;
+    filesScanned: number;
+    filesUpdated: number;
+    recordsMatched: number;
+    summary: Record<string, { applied: number; skipped: number; error: number }>;
+    sideEffects: number;
+    /** Present for the geocoder: count by precision tier. */
+    precisionTiers?: Record<string, number>;
+}
+
 export interface PreviewJobFile {
     /** Unique row id — the record's section_result_id (or a synthetic fallback). */
     id: string;
@@ -1461,6 +1473,26 @@ class ApiClient {
     getPreviewWellogicExportUrl(id: string, slug: string): string {
         const params = new URLSearchParams({ slug });
         return `${this.baseURL}/previews/${id}/export-wellogic?${params.toString()}`;
+    }
+
+    /** List the registered post-processing services (for the services panel). */
+    async getProcessingServices(): Promise<ApiResponse<{ services: { name: string; version: string }[] }>> {
+        return this.request('/previews/services');
+    }
+
+    /**
+     * Run a post-processing service over all records of a type in a preview.
+     * apply=false (default) is a dry-run: services execute and counts are
+     * returned, but nothing is persisted.
+     */
+    async runPreviewService(
+        id: string,
+        body: { name: string; slug: string; options?: Record<string, unknown>; apply?: boolean; force?: boolean },
+    ): Promise<ApiResponse<RunServiceResult>> {
+        return this.request(`/previews/${id}/run-service`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
     }
 
     async getPreviewStatistics(id: string): Promise<ApiResponse<{


### PR DESCRIPTION
Adds a **Processing Services** panel so geocoding and MGS enrichment are run from the UI instead of API calls — the frontend for the generalized `POST /previews/:id/run-service`.

## What
A "Services" button opens a right-side drawer listing registered services (Geocode locations, Enrich with MGS) with a plain-English description each. For the selected document type:
- **Preview (dry-run)** — runs the service and shows counts (records matched, applied/skipped/error, and the geocoder's precision-tier distribution) **without persisting**;
- **Apply** — persists, then refreshes the preview data.

## Changes
- `api.ts`: `getProcessingServices()`, `runPreviewService()`, `RunServiceResult`.
- `ServicesDrawer.tsx`: the panel (service cards, dry-run/apply, result tags).
- `page.tsx`: "Services" button + drawer wiring (refreshes on apply).

## Verification (in-browser)
Panel lists both services; geocode dry-run on Boring Logs returns "178 records, skipped 178" (idempotent — already geocoded); no console errors.

## Stacking / merge order
Stacked on **`feat/wellogic-export-ui`** (PR #47), which is stacked on backend **#46**. Merge order: #46 → #47 → this. The MGS "enrich on add" checkbox in `PreviewDrawer` is a separate surface; migrating it to `run-service` can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)