### PR TITLE
feat(preview): side-by-side PDF compare viewer in the record drawer

### DIFF
--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -24,7 +24,9 @@ import {
   Tooltip,
   notification,
   Spin,
+  Splitter,
 } from "antd";
+import dynamic from "next/dynamic";
 import { RecordView } from "@/components/record/RecordView";
 import { humanizeKey } from "@/components/record/recordSchema";
 import { PreviewRail, PreviewView, documentTypeLabel } from "./PreviewRail";
@@ -38,10 +40,26 @@ import {
   InfoCircleOutlined,
   ExpandOutlined,
   ReloadOutlined,
+  SplitCellsOutlined,
+  ExclamationCircleOutlined,
 } from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
 import { WellboreDiagramDrawer } from "@/components/well/WellboreDiagramModal";
 import { trackPreviewAnalytics } from "@/lib/previewAnalytics";
+
+// pdf.js (used by react-pdf) touches browser-only globals at import time, which
+// throws during SSR — load the side-by-side viewer client-side only.
+const PdfViewer = dynamic(
+  () => import("@/components/file/PdfViewer"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full items-center justify-center">
+        <Spin />
+      </div>
+    ),
+  },
+);
 
 // Styles for truncation and proper spacing
 const tableStyles = `
@@ -467,6 +485,45 @@ const PreviewPage: React.FC = () => {
   const [recordDrawer, setRecordDrawer] = useState<any>(null);
   const [exportDrawerOpen, setExportDrawerOpen] = useState(false);
 
+  // Side-by-side "Compare" mode in the record drawer: widens the drawer to full
+  // width and shows the source PDF (auto-scrolled to the record's page) next to
+  // the record. The signed PDF URL is fetched lazily, only when compare is on.
+  const [compareMode, setCompareMode] = useState(false);
+  const [comparePdfUrl, setComparePdfUrl] = useState<string | null>(null);
+  const [comparePdfLoading, setComparePdfLoading] = useState(false);
+
+  // Closing the drawer exits compare mode and drops the loaded PDF.
+  useEffect(() => {
+    if (!recordDrawer) {
+      setCompareMode(false);
+      setComparePdfUrl(null);
+    }
+  }, [recordDrawer]);
+
+  // Load the source PDF when compare turns on (or the selected record's file
+  // changes while comparing). Preview-scoped endpoint → works without auth.
+  const compareFileId = recordDrawer?._fileId as string | undefined;
+  useEffect(() => {
+    if (!compareMode || !compareFileId || !previewId) return;
+    let cancelled = false;
+    setComparePdfLoading(true);
+    setComparePdfUrl(null);
+    apiClient
+      .getPreviewFilePdfUrl(previewId, compareFileId)
+      .then((url) => {
+        if (!cancelled) setComparePdfUrl(url);
+      })
+      .catch((err) => {
+        if (!cancelled) console.error("Failed to load PDF for compare:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setComparePdfLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [compareMode, compareFileId, previewId]);
+
   useEffect(() => {
     document.title = previewData?.preview.name ?? "Preview";
   }, [previewData?.preview.name]);
@@ -709,6 +766,7 @@ const PreviewPage: React.FC = () => {
       _fileId: file.file_id ?? file.id,
       _slug: file.slug ?? null,
       _sectionId: file.section_result_id ?? null,
+      _sourcePage: file.source_page ?? null,
       _jobName: file.job_name,
       _createdAt: file.created_at,
       _adminVerified: file.admin_verified || false,
@@ -1672,31 +1730,89 @@ const PreviewPage: React.FC = () => {
         </div>
       </Modal>
 
-      {/* Record detail drawer — the schema-driven RecordView (engine + hero) */}
+      {/* Record detail drawer — the schema-driven RecordView (engine + hero).
+          "Compare" widens the drawer to full width and shows the source PDF
+          (auto-scrolled to the record's page) side-by-side with the record. */}
       <Drawer
         open={!!recordDrawer}
         onClose={() => setRecordDrawer(null)}
-        width={920}
+        width={compareMode ? "100%" : 920}
         title={recordDrawer?._filename}
-        styles={{ body: { background: "#f9fafb" } }}
+        styles={{
+          body: { background: "#f9fafb", padding: compareMode ? 0 : undefined },
+        }}
+        extra={
+          recordDrawer ? (
+            <Tooltip
+              title={
+                compareMode
+                  ? "Hide the source PDF"
+                  : "Show the source PDF next to this record"
+              }
+            >
+              <AntButton
+                type={compareMode ? "primary" : "default"}
+                icon={<SplitCellsOutlined />}
+                onClick={() => setCompareMode((v) => !v)}
+              >
+                {compareMode ? "Exit compare" : "Compare"}
+              </AntButton>
+            </Tooltip>
+          ) : null
+        }
         destroyOnClose
       >
-        {recordDrawer && (
-          <RecordView
-            data={recordDrawer._record ?? recordDrawer}
-            schema={previewData?.preview?.schema as never}
-            slug={recordDrawer._slug ?? undefined}
-            trust={{
-              verification:
-                recordDrawer._reviewStatus === "approved"
-                  ? "approved"
-                  : recordDrawer._reviewStatus === "rejected"
-                    ? "rejected"
-                    : "pending",
-              qa: null,
-            }}
-          />
-        )}
+        {recordDrawer &&
+          (() => {
+            const recordView = (
+              <RecordView
+                data={recordDrawer._record ?? recordDrawer}
+                schema={previewData?.preview?.schema as never}
+                slug={recordDrawer._slug ?? undefined}
+                trust={{
+                  verification:
+                    recordDrawer._reviewStatus === "approved"
+                      ? "approved"
+                      : recordDrawer._reviewStatus === "rejected"
+                        ? "rejected"
+                        : "pending",
+                  qa: null,
+                }}
+              />
+            );
+
+            if (!compareMode) return recordView;
+
+            return (
+              <Splitter className="h-full">
+                <Splitter.Panel defaultSize="50%" min={320}>
+                  <div className="flex h-full min-w-0 flex-col overflow-hidden bg-gray-100">
+                    {comparePdfLoading ? (
+                      <div className="flex h-full items-center justify-center">
+                        <Spin />
+                      </div>
+                    ) : comparePdfUrl ? (
+                      <PdfViewer
+                        url={comparePdfUrl}
+                        fileKey={recordDrawer._fileId}
+                        targetPage={recordDrawer._sourcePage ?? 1}
+                      />
+                    ) : (
+                      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-400">
+                        <ExclamationCircleOutlined className="mr-2" />
+                        Unable to load the source PDF for this record.
+                      </div>
+                    )}
+                  </div>
+                </Splitter.Panel>
+                <Splitter.Panel min={360}>
+                  <div className="h-full overflow-auto bg-[#f9fafb] px-4 py-2">
+                    {recordView}
+                  </div>
+                </Splitter.Panel>
+              </Splitter>
+            );
+          })()}
       </Drawer>
 
       {/* Wellbore Diagram Drawer */}

--- a/src/components/file/PdfViewer.tsx
+++ b/src/components/file/PdfViewer.tsx
@@ -45,12 +45,18 @@ type PdfViewerProps = {
   url: string;
   /** Resets internal state (page/zoom/rotation) when the file changes. */
   fileKey: string;
+  /**
+   * 1-based page to auto-scroll to once the document loads (and again whenever
+   * this value changes — e.g. selecting a different record). Only auto-navigates
+   * on change, so it never yanks the user back after they scroll away manually.
+   */
+  targetPage?: number | null;
 };
 
 const clamp = (n: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, n));
 
-export default function PdfViewer({ url, fileKey }: PdfViewerProps) {
+export default function PdfViewer({ url, fileKey, targetPage }: PdfViewerProps) {
   const [numPages, setNumPages] = useState(0);
   const [pageNumber, setPageNumber] = useState(1);
   const [zoom, setZoom] = useState(1); // 1 = fit container width
@@ -71,6 +77,10 @@ export default function PdfViewer({ url, fileKey }: PdfViewerProps) {
   const pageEls = useRef<Map<number, HTMLDivElement>>(new Map());
   const scrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const programmaticScroll = useRef(false);
+  // The (page, numPages) we last auto-navigated to, so the targetPage effect
+  // fires only when the target or the loaded doc actually changes — not on
+  // every resize/zoom re-render.
+  const appliedTarget = useRef<{ page: number; n: number } | null>(null);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -91,6 +101,7 @@ export default function PdfViewer({ url, fileKey }: PdfViewerProps) {
     setNumPages(0);
     setRenderSet(new Set());
     pageHeights.current.clear();
+    appliedTarget.current = null;
   }, [fileKey]);
 
   // Page geometry changed → previous placeholder heights are stale.
@@ -204,6 +215,26 @@ export default function PdfViewer({ url, fileKey }: PdfViewerProps) {
     },
     [numPages, viewMode, scrollToPage],
   );
+
+  // Parent-driven auto-navigation: scroll to targetPage once the doc is loaded
+  // and laid out, and again whenever the target (or loaded doc) changes. We
+  // scroll twice — immediately and after a short delay — because the continuous
+  // virtualizer sizes off-screen pages from an estimate until the first page
+  // measures; the second pass lands accurately once real heights are known.
+  useEffect(() => {
+    if (targetPage == null || numPages <= 0 || baseWidth <= 0) return;
+    const target = clamp(targetPage, 1, numPages);
+    const last = appliedTarget.current;
+    if (last && last.page === target && last.n === numPages) return;
+    appliedTarget.current = { page: target, n: numPages };
+    setPageNumber(target);
+    const t1 = setTimeout(() => scrollToPage(target), 0);
+    const t2 = setTimeout(() => scrollToPage(target), 250);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [targetPage, numPages, baseWidth, scrollToPage]);
 
   // When switching to continuous, jump to the page the user was on.
   useEffect(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -558,6 +558,12 @@ export interface PreviewJobFile {
     /** V2: the record's document type. */
     slug?: string | null;
     section_result_id?: string | null;
+    /**
+     * 1-based PDF page this record was extracted from (V2 per-section records),
+     * resolved from the file's detected_sections. null for V1 whole-doc records
+     * — the side-by-side viewer opens page 1 in that case.
+     */
+    source_page?: number | null;
 }
 
 export interface PreviewAnalyticsReport {
@@ -1424,6 +1430,24 @@ class ApiClient {
 
     async getPreviewData(id: string): Promise<ApiResponse<{ preview: PreviewDataTable; jobFiles: PreviewJobFile[] }>> {
         return this.request(`/previews/${id}/data`);
+    }
+
+    /**
+     * Preview-scoped signed PDF URL — works on the PUBLIC preview page (no auth
+     * token). Backed by GET /previews/:id/files/:fileId/download, which
+     * authorizes by preview membership instead of a user token. Used by the
+     * side-by-side compare viewer in the record drawer.
+     */
+    async getPreviewFilePdfUrl(previewId: string, fileId: string): Promise<string> {
+        const res = await fetch(
+            `${this.baseURL}/previews/${previewId}/files/${fileId}/download?format=json`,
+            { headers: { Accept: 'application/json' } },
+        );
+        if (!res.ok) {
+            throw new Error(`Failed to load PDF URL: ${res.status} ${res.statusText}`);
+        }
+        const data = await res.json();
+        return data.url as string;
     }
 
     async getPreviewDataPaginated(


### PR DESCRIPTION
The last open Phase-2 client deliverable (Khalid's P2): see an extracted record **next to the source PDF page it came from**, on the preview page.

**Requires the backend PR first:** Ayobamiu/text-to-structured-data#48 (provides `source_page` + the public preview-scoped PDF download endpoint).

## What
- **Compare toggle** in the record drawer. Toggling widens the drawer to full width and splits it (antd `Splitter`): source PDF on the left (½), record on the right (½). Toggling back returns to the 3/4 record-only drawer.
- The PDF **loads the whole document and auto-scrolls to the record's source page**; switching records re-navigates. V1/whole-doc records open page 1.
- PDF is fetched lazily (only when Compare is on) via the new public preview-scoped endpoint — works on the unauthenticated preview page.

## Decisions (confirmed with user)
- Full-width drawer on compare ✅
- Jump to **first** page for multi-page records ✅
- Region highlighting (`source_locations`) — **skipped** (out of scope)

## Reuse
- `PdfViewer.tsx` (lazy/virtualized page rendering) gained a `targetPage` prop that auto-scrolls on load and when the target changes, without yanking the user back on resize/zoom.
- Drawer split mirrors the jobs-page `FileViewerLayout` `Splitter` pattern.

## Testing
Verified on the **Sara V1** preview against a local backend on real data:
- Drawer goes full-width with the PDF | record split.
- **MW#3 → page 3**, **MW#2 → page 5** — and each PDF page's boring-log content matches the record shown.
- Switching records re-navigates; lazy rendering works on multi-page docs; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)