### PR TITLE
feat(preview): label record ID column by per-document-type identifier field

### DIFF
--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -7,7 +7,12 @@ import {
   usePathname,
   useSearchParams,
 } from "next/navigation";
-import { apiClient, PreviewDataTable, PreviewJobFile } from "@/lib/api";
+import {
+  apiClient,
+  PreviewDataTable,
+  PreviewJobFile,
+  PreviewSlugCount,
+} from "@/lib/api";
 import {
   getCachedPreviewData,
   setCachedPreviewData,
@@ -177,9 +182,40 @@ function scalarField(obj: any, key: string): string | null {
   return null;
 }
 
-/** Resolve the identifier value used to label a record row, or null if none. */
-function recordIdentifier(record: any): string | null {
+/** Resolve a dot-path (e.g. "site_identification.boring_well_id") to a scalar. */
+function resolveDotPath(record: any, path: string): string | null {
+  const parts = path.split(".");
+  let cur = record;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (!cur || typeof cur !== "object") return null;
+    cur = cur[parts[i]];
+  }
+  return scalarField(cur, parts[parts.length - 1]);
+}
+
+/**
+ * Resolve the identifier value used to label a record row, or null if none.
+ *
+ * `configuredFields` is the record's document type's per-type dot-paths (from the
+ * backend, keyed by slug). When present they win — exact, vendor-specific, in
+ * priority order. With no config we fall back to the global heuristic (a field
+ * priority list crossed with common container objects).
+ */
+function recordIdentifier(
+  record: any,
+  configuredFields?: string[] | null,
+): string | null {
   if (!record || typeof record !== "object") return null;
+
+  // 1. Configured dot-paths for this record's type (preferred).
+  if (Array.isArray(configuredFields)) {
+    for (const path of configuredFields) {
+      const v = resolveDotPath(record, path);
+      if (v) return v;
+    }
+  }
+
+  // 2. Heuristic fallback for unconfigured types.
   for (const field of ID_FIELD_PRIORITY) {
     for (const container of ID_CONTAINERS) {
       const obj = container ? record[container] : record;
@@ -454,9 +490,7 @@ const PreviewPage: React.FC = () => {
 
   // Rail navigation: which lens is active.
   const [view, setView] = useState<PreviewView>(initialUrl.view);
-  const [slugs, setSlugs] = useState<
-    Array<{ slug: string | null; count: number }>
-  >([]);
+  const [slugs, setSlugs] = useState<PreviewSlugCount[]>([]);
   const [fileSummaries, setFileSummaries] = useState<any[]>([]);
   const [filesTotal, setFilesTotal] = useState<number>(0);
 
@@ -489,12 +523,25 @@ const PreviewPage: React.FC = () => {
   };
 
   // Create Ant Design table columns
+  // Per-type identifier dot-paths, keyed by slug, from the rail distribution.
+  // Lets a record row be labeled by the field its document type configures
+  // (borehole_log → site_identification.boring_well_id, mgs_well_log →
+  // well_number); unconfigured types fall back to the heuristic.
+  const idFieldsBySlug = useMemo(() => {
+    const map = new Map<string | null, string[] | null>();
+    for (const s of slugs) map.set(s.slug ?? null, s.identifier_fields ?? null);
+    return map;
+  }, [slugs]);
+
   const tableColumns: ColumnsType<any> = useMemo(() => {
     // When showing files, the first fixed column is the filename. When showing
     // records, it's the record's identifier (e.g. boring_well_id) instead — the
     // filename is repetitive there (one file can yield many records).
     const showingFiles = view.kind === "files";
-   
+
+    // Resolve a record's identifier using its type's configured dot-paths.
+    const idOf = (record: any): string | null =>
+      recordIdentifier(record, idFieldsBySlug.get(record._slug ?? null));
 
     const baseColumns: ColumnsType<any> = [
       {
@@ -504,22 +551,17 @@ const PreviewPage: React.FC = () => {
         fixed: "left",
         ellipsis: true,
         sorter: (a, b) => {
-          const aLabel = showingFiles
-            ? a._filename
-            : recordIdentifier(a) ?? a._filename ?? "";
-          const bLabel = showingFiles
-            ? b._filename
-            : recordIdentifier(b) ?? b._filename ?? "";
+          const aLabel = showingFiles ? a._filename : idOf(a) ?? a._filename ?? "";
+          const bLabel = showingFiles ? b._filename : idOf(b) ?? b._filename ?? "";
           return String(aLabel).localeCompare(String(bLabel));
         },
         render: (_: unknown, record: any) => {
           // Identifier shown in the cell — filename in files view, record id
           // otherwise. Fall back to filename when a record has no id value.
-          const id = showingFiles ? null : recordIdentifier(record);
+          const id = showingFiles ? null : idOf(record);
           const label = showingFiles
             ? record._filename
             : id ?? record._filename;
-           console.log({id,label, showingFiles})
           const isFallback = !showingFiles && !id;
 
           // Check if record has well data (formations, casing, etc.)
@@ -694,7 +736,7 @@ const PreviewPage: React.FC = () => {
     };
 
     return [...baseColumns, ...dynamicColumns, qaStatusColumn];
-  }, [columns, handleArrayClick, view.kind, previewId]);
+  }, [columns, handleArrayClick, view.kind, previewId, idFieldsBySlug]);
 
   // Process data (no client-side filtering since we use server-side search)
   const processedData = useMemo(() => {
@@ -1686,6 +1728,7 @@ const PreviewPage: React.FC = () => {
             data={recordDrawer._record ?? recordDrawer}
             schema={previewData?.preview?.schema as never}
             slug={recordDrawer._slug ?? undefined}
+            identifierFields={idFieldsBySlug.get(recordDrawer._slug ?? null)}
             trust={{
               verification:
                 recordDrawer._reviewStatus === "approved"

--- a/src/components/record/RecordTrustHeader.tsx
+++ b/src/components/record/RecordTrustHeader.tsx
@@ -59,8 +59,16 @@ function pick(obj: unknown, path: string[]): unknown {
   return cur;
 }
 
-function recordTitle(data: Record<string, unknown>): string | null {
+function recordTitle(
+  data: Record<string, unknown>,
+  identifierFields?: string[] | null,
+): string | null {
+  // Configured dot-paths for this record's type win (kept in sync with the
+  // preview ID column); the hardcoded list is the fallback for unconfigured types.
   const candidates: Array<unknown> = [
+    ...(Array.isArray(identifierFields)
+      ? identifierFields.map((path) => pick(data, path.split(".")))
+      : []),
     pick(data, ["site_identification", "boring_well_id"]),
     pick(data, ["site_identification", "boring_well_id_full"]),
     pick(data, ["test_setup", "well_number"]),
@@ -122,13 +130,16 @@ export function RecordTrustHeader({
   data,
   slug,
   trust,
+  identifierFields,
 }: {
   data: Record<string, unknown>;
   slug?: string;
   trust?: RecordTrust;
+  /** Per-type identifier dot-paths (kept in sync with the preview ID column). */
+  identifierFields?: string[] | null;
 }) {
   const docName = slug ? SLUG_NAMES[slug] ?? humanizeKey(slug) : "Record";
-  const title = recordTitle(data);
+  const title = recordTitle(data, identifierFields);
 
   const meta = (data["extraction_metadata"] ?? {}) as Record<string, unknown>;
   const rawSource =

--- a/src/components/record/RecordView.tsx
+++ b/src/components/record/RecordView.tsx
@@ -20,6 +20,7 @@ export function RecordView({
   fieldDescriptions,
   trust,
   hero,
+  identifierFields,
 }: {
   data: Record<string, unknown>;
   schema?: JsonSchemaNode;
@@ -28,6 +29,8 @@ export function RecordView({
   trust?: RecordTrust;
   /** Override the registry hero (e.g. for testing). */
   hero?: HeroComponent | null;
+  /** Per-type identifier dot-paths for the header title (preview ID config). */
+  identifierFields?: string[] | null;
 }) {
   const descMap = useMemo<Record<string, string>>(
     () => fieldDescriptions ?? (schema ? buildFieldDescriptionMap(schema) : {}),
@@ -47,7 +50,12 @@ export function RecordView({
 
   return (
     <div className="max-w-5xl mx-auto px-1 py-2">
-      <RecordTrustHeader data={data} slug={slug} trust={trust} />
+      <RecordTrustHeader
+        data={data}
+        slug={slug}
+        trust={trust}
+        identifierFields={identifierFields}
+      />
       {Hero && (
         <div className="mb-5">
           <Hero data={data} />

--- a/src/components/registry/SchemaRegistryAdmin.tsx
+++ b/src/components/registry/SchemaRegistryAdmin.tsx
@@ -69,6 +69,9 @@ export default function SchemaRegistryAdmin() {
   const [ppServices, setPpServices] = useState<{ name: string; version: string }[]>([]);
   const [ppEnabled, setPpEnabled] = useState<Record<string, boolean>>({});
   const [ppSaving, setPpSaving] = useState(false);
+  // Per-type record identifier dot-paths (preview ID column), one per line.
+  const [idFieldsText, setIdFieldsText] = useState("");
+  const [idSaving, setIdSaving] = useState(false);
   const [newSchemaText, setNewSchemaText] = useState("");
   const [newSchemaOpen, setNewSchemaOpen] = useState(false);
   const [schemaView, setSchemaView] = useState<{
@@ -130,6 +133,7 @@ export default function SchemaRegistryAdmin() {
         if (d && typeof d.name === "string") seeded[d.name] = d.enabled !== false;
       }
       setPpEnabled(seeded);
+      setIdFieldsText((res.documentType.identifier_fields ?? []).join("\n"));
     } finally {
       setDetailLoading(false);
     }
@@ -218,6 +222,28 @@ export default function SchemaRegistryAdmin() {
       } else message.error(res.message || "Save failed");
     } catch {
       message.error("Invalid JSON in classifier hints");
+    }
+  };
+
+  const saveIdentifierFields = async () => {
+    if (!manageSlug) return;
+    // One dot-path per line; blank lines ignored. Empty list clears (→ heuristic).
+    const fields = idFieldsText
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setIdSaving(true);
+    try {
+      const res = await apiClient.registryPutIdentifierFields(manageSlug, fields);
+      if (res.success) {
+        message.success(
+          fields.length ? "Record ID field saved" : "Record ID field cleared",
+        );
+        openManage(manageSlug);
+        loadTypes();
+      } else message.error(res.message || "Save failed");
+    } finally {
+      setIdSaving(false);
     }
   };
 
@@ -689,6 +715,39 @@ export default function SchemaRegistryAdmin() {
                         onClick={savePostProcessing}
                       >
                         Save defaults
+                      </Button>
+                    </Space>
+                  </div>
+                ),
+              },
+              {
+                key: "identifier",
+                label: "Record ID field",
+                children: (
+                  <div className="space-y-3 pt-2">
+                    <Paragraph type="secondary" className="!text-xs">
+                      Which field labels a record in the preview&apos;s ID column
+                      (and the record drawer header). Enter one dot-path per line,
+                      tried in order — the first with a value wins. Example:{" "}
+                      <span className="font-mono">
+                        site_identification.boring_well_id
+                      </span>
+                      . Leave empty to fall back to the automatic heuristic.
+                    </Paragraph>
+                    <TextArea
+                      value={idFieldsText}
+                      onChange={(e) => setIdFieldsText(e.target.value)}
+                      placeholder={"site_identification.boring_well_id\nboring_well_id"}
+                      autoSize={{ minRows: 4, maxRows: 10 }}
+                      className="font-mono !text-xs"
+                    />
+                    <Space>
+                      <Button
+                        type="primary"
+                        loading={idSaving}
+                        onClick={saveIdentifierFields}
+                      >
+                        Save ID field
                       </Button>
                     </Space>
                   </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -543,6 +543,17 @@ export interface PreviewDataTable {
     item_count?: number;
 }
 
+/**
+ * One entry in a preview's record-type distribution (the rail). `identifier_fields`
+ * is the document type's configured ordered dot-paths for labeling a record row in
+ * the ID column (null for untyped / unconfigured types → frontend heuristic fallback).
+ */
+export interface PreviewSlugCount {
+    slug: string | null;
+    count: number;
+    identifier_fields?: string[] | null;
+}
+
 export interface PreviewJobFile {
     /** Unique row id — the record's section_result_id (or a synthetic fallback). */
     id: string;
@@ -1435,7 +1446,7 @@ class ApiClient {
     ): Promise<ApiResponse<{
         preview: PreviewDataTable;
         jobFiles: PreviewJobFile[];
-        slugs?: Array<{ slug: string | null; count: number }>;
+        slugs?: PreviewSlugCount[];
         pagination: {
             total: number;
             page: number;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -259,6 +259,7 @@ export interface RegistryDocumentTypeDetail {
     status: string;
     classifier_hints?: Record<string, unknown> | null;
     post_processing_defaults?: PostProcessingOverride[] | null;
+    identifier_fields?: string[] | null;
     created_at?: string;
     updated_at?: string;
     current_schema_version_id?: string | null;
@@ -1014,6 +1015,17 @@ class ApiClient {
         return this.request(`/registry/document-types/${encodeURIComponent(slug)}/classifier-hints`, {
             method: 'PUT',
             body: JSON.stringify({ hints }),
+        });
+    }
+
+    /** Replace a document type's identifier dot-paths (preview ID column label). [] clears. */
+    async registryPutIdentifierFields(
+        slug: string,
+        fields: string[]
+    ): Promise<ApiResponse<{ identifier_fields: string[]; updated_at: string }>> {
+        return this.request(`/registry/document-types/${encodeURIComponent(slug)}/identifier-fields`, {
+            method: 'PUT',
+            body: JSON.stringify({ fields }),
         });
     }
 


### PR DESCRIPTION
Labels a record in the preview's left fixed **ID column** by its document type's configured identifier field, instead of the global field-name heuristic.

**Requires the backend PR first:** Ayobamiu/text-to-structured-data#49 (adds `identifier_fields` to each `slugs[]` entry in `/previews/:id/data`).

## What
- `recordIdentifier(record, configuredFields)` now tries the type's configured **dot-paths** first (in order), then falls back to the existing heuristic. New `resolveDotPath` helper.
- Build a `slug → identifier_fields` map from the rail's `slugs` response; each record row is resolved by its `_slug`.
- Thread `identifierFields` through `RecordView → RecordTrustHeader`, so the drawer header title and the ID column always agree.
- Removed a stray per-cell `console.log`.

## Behavior
- `borehole_log` → `site_identification.boring_well_id` (no longer mislabeled by a stray root field).
- `mgs_well_log` → `well_number`.
- Any type **without** config keeps today's heuristic — nothing regresses.

## Testing
- `tsc` clean for all touched files (the pre-existing `Button.tsx` framer-motion error is unrelated).
- Resolution logic verified offline: configured-nested wins over a misleading root `well_number`; root-level config resolves; unconfigured and configured-but-absent both fall back to the heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)