### PR TITLE
NL query: AI chat panel on the preview page

### DIFF
--- a/src/app/preview/[id]/page.tsx
+++ b/src/app/preview/[id]/page.tsx
@@ -12,7 +12,11 @@ import {
   PreviewDataTable,
   PreviewJobFile,
   PreviewSlugCount,
+  type NlChatScope,
 } from "@/lib/api";
+import { useAuth } from "@/contexts/AuthContext";
+import AiChatPanel from "@/components/nlquery/AiChatPanel";
+import { Sparkles } from "lucide-react";
 import {
   getCachedPreviewData,
   setCachedPreviewData,
@@ -54,17 +58,14 @@ import { trackPreviewAnalytics } from "@/lib/previewAnalytics";
 
 // pdf.js (used by react-pdf) touches browser-only globals at import time, which
 // throws during SSR — load the side-by-side viewer client-side only.
-const PdfViewer = dynamic(
-  () => import("@/components/file/PdfViewer"),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-full items-center justify-center">
-        <Spin />
-      </div>
-    ),
-  },
-);
+const PdfViewer = dynamic(() => import("@/components/file/PdfViewer"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center">
+      <Spin />
+    </div>
+  ),
+});
 
 // Styles for truncation and proper spacing
 const tableStyles = `
@@ -526,11 +527,20 @@ const PreviewPage: React.FC = () => {
   const [comparePdfUrl, setComparePdfUrl] = useState<string | null>(null);
   const [comparePdfLoading, setComparePdfLoading] = useState(false);
 
+  // The conversational AI chat panel. It's authed + org-scoped (the preview page
+  // itself is public), so the entry points only appear for signed-in operators.
+  const { isAuthenticated } = useAuth();
+  // Preview-page panel (scope follows the left-rail `view`).
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
+  // Record-drawer panel (scope = the one open record). Squeezes alongside Compare.
+  const [aiDrawerOpen, setAiDrawerOpen] = useState(false);
+
   // Closing the drawer exits compare mode and drops the loaded PDF.
   useEffect(() => {
     if (!recordDrawer) {
       setCompareMode(false);
       setComparePdfUrl(null);
+      setAiDrawerOpen(false);
     }
   }, [recordDrawer]);
 
@@ -608,8 +618,12 @@ const PreviewPage: React.FC = () => {
         fixed: "left",
         ellipsis: true,
         sorter: (a, b) => {
-          const aLabel = showingFiles ? a._filename : idOf(a) ?? a._filename ?? "";
-          const bLabel = showingFiles ? b._filename : idOf(b) ?? b._filename ?? "";
+          const aLabel = showingFiles
+            ? a._filename
+            : (idOf(a) ?? a._filename ?? "");
+          const bLabel = showingFiles
+            ? b._filename
+            : (idOf(b) ?? b._filename ?? "");
           return String(aLabel).localeCompare(String(bLabel));
         },
         render: (_: unknown, record: any) => {
@@ -618,7 +632,7 @@ const PreviewPage: React.FC = () => {
           const id = showingFiles ? null : idOf(record);
           const label = showingFiles
             ? record._filename
-            : id ?? record._filename;
+            : (id ?? record._filename);
           const isFallback = !showingFiles && !id;
 
           // Check if record has well data (formations, casing, etc.)
@@ -1143,7 +1157,9 @@ const PreviewPage: React.FC = () => {
   // Wellogic-format multi-tab Excel (Wells + linked Lithology) for the type.
   const handleWellogicExport = () => {
     if (!gisExportSlug) return;
-    triggerDownload(apiClient.getPreviewWellogicExportUrl(previewId, gisExportSlug));
+    triggerDownload(
+      apiClient.getPreviewWellogicExportUrl(previewId, gisExportSlug),
+    );
   };
 
   const handleExport = (format: "csv" | "json") => {
@@ -1271,6 +1287,25 @@ const PreviewPage: React.FC = () => {
     return null; // This shouldn't happen, but satisfies TypeScript
   }
 
+  // AI chat scope + button copy for the preview-page panel, derived from the
+  // left-rail `view` (the 4 contexts the handoff spec'd).
+  const truncateName = (s: string) =>
+    s.length > 28 ? `${s.slice(0, 27)}…` : s;
+  const previewAiScope: NlChatScope =
+    view.kind === "file"
+      ? { fileId: view.fileId }
+      : view.kind === "records" && view.slug
+        ? { previewId, slug: view.slug }
+        : { previewId }; // records (all) or files (all)
+  const previewAiTitle =
+    view.kind === "file"
+      ? `Ask about ${truncateName(view.filename)}`
+      : view.kind === "records" && view.slug
+        ? `Ask about ${documentTypeLabel(view.slug)}`
+        : view.kind === "files"
+          ? "Ask about all files"
+          : "Ask about all records";
+
   return (
     <div className="h-screen bg-gray-50 flex flex-col">
       <style dangerouslySetInnerHTML={{ __html: tableStyles }} />
@@ -1300,7 +1335,7 @@ const PreviewPage: React.FC = () => {
                   />
                 )}
               </div>
-              <span className="text-lg font-semibold text-gray-900">
+              <span className="text-lg font-semibold text-gray-900 truncate max-w-[100px]">
                 {previewData.preview.name}
               </span>
             </div>
@@ -1410,9 +1445,9 @@ const PreviewPage: React.FC = () => {
               <div className="flex flex-col gap-3">
                 {!gisExportSlug && (
                   <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-                    Select a document type in the left rail to enable the Wellogic
-                    and GIS exports — they export <strong>all</strong> records of
-                    one type, not just this page.
+                    Select a document type in the left rail to enable the
+                    Wellogic and GIS exports — they export <strong>all</strong>{" "}
+                    records of one type, not just this page.
                   </div>
                 )}
                 {gisExportSlug && (
@@ -1481,135 +1516,152 @@ const PreviewPage: React.FC = () => {
           view={view}
           onSelect={setView}
         />
-        <div className="flex-1 overflow-hidden flex flex-col">
-          {view.kind === "file" && (
-            <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-100 text-sm bg-white">
-              <button
-                type="button"
-                className="text-blue-600 hover:underline bg-transparent border-0 p-0 cursor-pointer"
-                onClick={() => setView({ kind: "files" })}
-              >
-                ← Files
-              </button>
-              <span className="text-gray-400">/</span>
-              <span className="text-gray-700 truncate">{view.filename}</span>
-            </div>
-          )}
+        <Splitter className="flex-1 overflow-hidden">
+          <Splitter.Panel min="45%">
+            <div className="h-full w-full overflow-hidden flex flex-col">
+              {view.kind === "file" && (
+                <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-100 text-sm bg-white">
+                  <button
+                    type="button"
+                    className="text-blue-600 hover:underline bg-transparent border-0 p-0 cursor-pointer"
+                    onClick={() => setView({ kind: "files" })}
+                  >
+                    ← Files
+                  </button>
+                  <span className="text-gray-400">/</span>
+                  <span className="text-gray-700 truncate">
+                    {view.filename}
+                  </span>
+                </div>
+              )}
 
-          {view.kind === "files" ? (
-            <Table
-              columns={[
-                {
-                  title: "File",
-                  dataIndex: "filename",
-                  key: "filename",
-                  ellipsis: true,
-                  render: (text: string, f: any) => (
-                    <button
-                      type="button"
-                      className="text-blue-600 hover:text-blue-800 hover:underline text-left bg-transparent border-0 p-0 cursor-pointer truncate block"
-                      title={`Open ${text}`}
-                      onClick={() =>
-                        setView({
-                          kind: "file",
-                          fileId: f.id,
-                          filename: f.filename,
-                        })
-                      }
-                    >
-                      {text}
-                    </button>
-                  ),
-                },
-                {
-                  title: "Contents",
-                  key: "contents",
-                  render: (_: unknown, f: any) =>
-                    f.by_type && f.by_type.length
-                      ? f.by_type
-                          .map(
-                            (t: { slug: string | null; count: number }) =>
-                              `${t.count} ${documentTypeLabel(t.slug)}`,
-                          )
-                          .join(" · ")
-                      : `${f.total_records} records`,
-                },
-                {
-                  title: "Records",
-                  dataIndex: "total_records",
-                  key: "total_records",
-                  width: 90,
-                  align: "right" as const,
-                },
-                {
-                  title: "Status",
-                  dataIndex: "review_status",
-                  key: "review_status",
-                  width: 120,
-                  render: (s: string) => <Tag>{s || "pending"}</Tag>,
-                },
-              ]}
-              dataSource={fileSummaries}
-              rowKey="id"
-              loading={loading}
-              scroll={{ y: "calc(100vh - 200px)" }}
-              pagination={
-                filesTotal > pageSize
-                  ? {
-                      current: currentPage,
-                      total: filesTotal,
-                      pageSize,
-                      onChange: (p) => setCurrentPage(p),
-                      size: "small",
-                      position: ["bottomCenter"],
-                    }
-                  : false
-              }
-              size="small"
-              className="ant-table-custom"
-            />
-          ) : (
-            <Table
-              columns={tableColumns}
-              bordered
-              dataSource={processedData}
-              rowKey={(record) =>
-                record._rowId ?? `${record._fileId}-${record._filename}`
-              }
-              scroll={{ x: "max-content", y: "calc(100vh - 200px)" }}
-              loading={loading}
-              pagination={
-                totalItems > 0 && !loading && processedData.length <= pageSize
-                  ? {
-                      current: currentPage,
-                      total: totalItems,
-                      pageSize: pageSize,
-                      showSizeChanger: true,
-                      showQuickJumper: false,
-                      showTotal: (total, range) =>
-                        `${range[0]}-${range[1]} of ${total} items`,
-                      onChange: (page, size) => {
-                        setCurrentPage(page);
-                        if (size !== pageSize) {
-                          setPageSize(size);
+              {view.kind === "files" ? (
+                <Table
+                  columns={[
+                    {
+                      title: "File",
+                      dataIndex: "filename",
+                      key: "filename",
+                      ellipsis: true,
+                      render: (text: string, f: any) => (
+                        <button
+                          type="button"
+                          className="text-blue-600 hover:text-blue-800 hover:underline text-left bg-transparent border-0 p-0 cursor-pointer truncate block"
+                          title={`Open ${text}`}
+                          onClick={() =>
+                            setView({
+                              kind: "file",
+                              fileId: f.id,
+                              filename: f.filename,
+                            })
+                          }
+                        >
+                          {text}
+                        </button>
+                      ),
+                    },
+                    {
+                      title: "Contents",
+                      key: "contents",
+                      render: (_: unknown, f: any) =>
+                        f.by_type && f.by_type.length
+                          ? f.by_type
+                              .map(
+                                (t: { slug: string | null; count: number }) =>
+                                  `${t.count} ${documentTypeLabel(t.slug)}`,
+                              )
+                              .join(" · ")
+                          : `${f.total_records} records`,
+                    },
+                    {
+                      title: "Records",
+                      dataIndex: "total_records",
+                      key: "total_records",
+                      width: 90,
+                      align: "right" as const,
+                    },
+                    {
+                      title: "Status",
+                      dataIndex: "review_status",
+                      key: "review_status",
+                      width: 120,
+                      render: (s: string) => <Tag>{s || "pending"}</Tag>,
+                    },
+                  ]}
+                  dataSource={fileSummaries}
+                  rowKey="id"
+                  loading={loading}
+                  scroll={{ y: "calc(100vh - 200px)" }}
+                  pagination={
+                    filesTotal > pageSize
+                      ? {
+                          current: currentPage,
+                          total: filesTotal,
+                          pageSize,
+                          onChange: (p) => setCurrentPage(p),
+                          size: "small",
+                          position: ["bottomCenter"],
                         }
-                      },
-                      onShowSizeChange: (current, size) => {
-                        setCurrentPage(1);
-                        setPageSize(size);
-                      },
-                      size: "small",
-                      hideOnSinglePage: totalPages <= 1,
-                      position: ["bottomCenter"],
-                      pageSizeOptions: ["10", "20", "50", "100"],
-                    }
-                  : false
-              }
-              size="small"
-              className="ant-table-custom h-full"
-            />
+                      : false
+                  }
+                  size="small"
+                  className="ant-table-custom"
+                />
+              ) : (
+                <Table
+                  columns={tableColumns}
+                  bordered
+                  dataSource={processedData}
+                  rowKey={(record) =>
+                    record._rowId ?? `${record._fileId}-${record._filename}`
+                  }
+                  scroll={{ x: "max-content", y: "calc(100vh - 200px)" }}
+                  loading={loading}
+                  pagination={
+                    totalItems > 0 &&
+                    !loading &&
+                    processedData.length <= pageSize
+                      ? {
+                          current: currentPage,
+                          total: totalItems,
+                          pageSize: pageSize,
+                          showSizeChanger: true,
+                          showQuickJumper: false,
+                          showTotal: (total, range) =>
+                            `${range[0]}-${range[1]} of ${total} items`,
+                          onChange: (page, size) => {
+                            setCurrentPage(page);
+                            if (size !== pageSize) {
+                              setPageSize(size);
+                            }
+                          },
+                          onShowSizeChange: (current, size) => {
+                            setCurrentPage(1);
+                            setPageSize(size);
+                          },
+                          size: "small",
+                          hideOnSinglePage: totalPages <= 1,
+                          position: ["bottomCenter"],
+                          pageSizeOptions: ["10", "20", "50", "100"],
+                        }
+                      : false
+                  }
+                  size="small"
+                  className="ant-table-custom h-full"
+                />
+              )}
+            </div>
+          </Splitter.Panel>
+          {aiPanelOpen && isAuthenticated && (
+            <Splitter.Panel defaultSize={440} min={320} collapsible>
+              <AiChatPanel
+                scope={previewAiScope}
+                title={previewAiTitle}
+                onClose={() => setAiPanelOpen(false)}
+              />
+            </Splitter.Panel>
           )}
-        </div>
+        </Splitter>
       </div>
 
       {/* Quality Score Info Modal */}
@@ -1778,28 +1830,45 @@ const PreviewPage: React.FC = () => {
       <Drawer
         open={!!recordDrawer}
         onClose={() => setRecordDrawer(null)}
-        width={compareMode ? "100%" : 920}
+        width={compareMode || aiDrawerOpen ? "100%" : 920}
         title={recordDrawer?._filename}
         styles={{
-          body: { background: "#f9fafb", padding: compareMode ? 0 : undefined },
+          body: {
+            background: "#f9fafb",
+            padding: compareMode || aiDrawerOpen ? 0 : undefined,
+          },
         }}
         extra={
           recordDrawer ? (
-            <Tooltip
-              title={
-                compareMode
-                  ? "Hide the source PDF"
-                  : "Show the source PDF next to this record"
-              }
-            >
-              <AntButton
-                type={compareMode ? "primary" : "default"}
-                icon={<SplitCellsOutlined />}
-                onClick={() => setCompareMode((v) => !v)}
+            <div className="flex items-center gap-2">
+              {/* AI chat about this single record — authed operators only. */}
+              {isAuthenticated && (
+                <Tooltip title="Ask AI about this record">
+                  <AntButton
+                    type={aiDrawerOpen ? "primary" : "default"}
+                    icon={<Sparkles size={15} />}
+                    onClick={() => setAiDrawerOpen((v) => !v)}
+                  >
+                    {aiDrawerOpen ? "Close AI" : "Ask AI"}
+                  </AntButton>
+                </Tooltip>
+              )}
+              <Tooltip
+                title={
+                  compareMode
+                    ? "Hide the source PDF"
+                    : "Show the source PDF next to this record"
+                }
               >
-                {compareMode ? "Exit compare" : "Compare"}
-              </AntButton>
-            </Tooltip>
+                <AntButton
+                  type={compareMode ? "primary" : "default"}
+                  icon={<SplitCellsOutlined />}
+                  onClick={() => setCompareMode((v) => !v)}
+                >
+                  {compareMode ? "Exit compare" : "Compare"}
+                </AntButton>
+              </Tooltip>
+            </div>
           ) : null
         }
         destroyOnClose
@@ -1826,35 +1895,59 @@ const PreviewPage: React.FC = () => {
               />
             );
 
-            if (!compareMode) return recordView;
+            // Neither Compare nor AI open → just the record (drawer at 920px).
+            if (!compareMode && !aiDrawerOpen) return recordView;
+
+            // Otherwise squeeze whichever panels are active into one Splitter:
+            // [PDF (compare)] · [record] · [AI chat]. 2-way or 3-way, same code.
+            const pdfPanel = compareMode ? (
+              <Splitter.Panel key="pdf" defaultSize="40%" min={300}>
+                <div className="flex h-full min-w-0 flex-col overflow-hidden bg-gray-100">
+                  {comparePdfLoading ? (
+                    <div className="flex h-full items-center justify-center">
+                      <Spin />
+                    </div>
+                  ) : comparePdfUrl ? (
+                    <PdfViewer
+                      url={comparePdfUrl}
+                      fileKey={recordDrawer._fileId}
+                      targetPage={recordDrawer._sourcePage ?? 1}
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-400">
+                      <ExclamationCircleOutlined className="mr-2" />
+                      Unable to load the source PDF for this record.
+                    </div>
+                  )}
+                </div>
+              </Splitter.Panel>
+            ) : null;
+
+            const recordPanel = (
+              <Splitter.Panel key="record" min={340}>
+                <div className="h-full overflow-auto bg-[#f9fafb] px-4 py-2">
+                  {recordView}
+                </div>
+              </Splitter.Panel>
+            );
+
+            const aiPanel = aiDrawerOpen ? (
+              <Splitter.Panel key="ai" defaultSize={420} min={320}>
+                <AiChatPanel
+                  scope={{
+                    // record_uid = section_result_id (V2) or file_id (V1).
+                    recordId: recordDrawer._sectionId ?? recordDrawer._fileId,
+                    slug: recordDrawer._slug ?? undefined,
+                  }}
+                  title="Ask about this record"
+                  onClose={() => setAiDrawerOpen(false)}
+                />
+              </Splitter.Panel>
+            ) : null;
 
             return (
               <Splitter className="h-full">
-                <Splitter.Panel defaultSize="50%" min={320}>
-                  <div className="flex h-full min-w-0 flex-col overflow-hidden bg-gray-100">
-                    {comparePdfLoading ? (
-                      <div className="flex h-full items-center justify-center">
-                        <Spin />
-                      </div>
-                    ) : comparePdfUrl ? (
-                      <PdfViewer
-                        url={comparePdfUrl}
-                        fileKey={recordDrawer._fileId}
-                        targetPage={recordDrawer._sourcePage ?? 1}
-                      />
-                    ) : (
-                      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-400">
-                        <ExclamationCircleOutlined className="mr-2" />
-                        Unable to load the source PDF for this record.
-                      </div>
-                    )}
-                  </div>
-                </Splitter.Panel>
-                <Splitter.Panel min={360}>
-                  <div className="h-full overflow-auto bg-[#f9fafb] px-4 py-2">
-                    {recordView}
-                  </div>
-                </Splitter.Panel>
+                {[pdfPanel, recordPanel, aiPanel].filter(Boolean)}
               </Splitter>
             );
           })()}
@@ -1875,20 +1968,35 @@ const PreviewPage: React.FC = () => {
 
       {/* Core Extract Footer Signature */}
       <div className="border-t border-gray-100 px-6 py-3 flex-shrink-0">
-        <div className="flex items-center justify-center space-x-2 text-gray-400">
-          <span className="text-sm">
-            Powered by{" "}
-            <a
-              href="#"
-              className="text-blue-600 hover:text-blue-800 transition-colors duration-200"
-              onClick={(e) => {
-                e.preventDefault();
-                window.open("https://coreextract.app", "_blank");
-              }}
-            >
-              Core Extract
-            </a>
-          </span>
+        <div className="flex items-center justify-between gap-2">
+          <div className="w-48" />
+          <div className="flex flex-1 items-center justify-center space-x-2 text-gray-400">
+            <span className="text-sm">
+              Powered by{" "}
+              <a
+                href="#"
+                className="text-blue-600 hover:text-blue-800 transition-colors duration-200"
+                onClick={(e) => {
+                  e.preventDefault();
+                  window.open("https://coreextract.app", "_blank");
+                }}
+              >
+                Core Extract
+              </a>
+            </span>
+          </div>
+          <div className="flex w-48 justify-end">
+            {/* AI chat entry point — authed operators only (the panel is org-scoped). */}
+            {isAuthenticated && (
+              <AntButton
+                type={aiPanelOpen ? "primary" : "default"}
+                icon={<Sparkles size={15} />}
+                onClick={() => setAiPanelOpen((v) => !v)}
+              >
+                {aiPanelOpen ? "Close AI" : previewAiTitle}
+              </AntButton>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/query/page.tsx
+++ b/src/app/query/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, Typography, Input, Button, Table, Alert, Tag, Empty, Space } from "antd";
+import { Search, Download } from "lucide-react";
+import SidebarLayout from "@/components/layout/SidebarLayout";
+import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import { apiClient } from "@/lib/api";
+
+const { Title, Text, Paragraph } = Typography;
+
+interface QueryData {
+  interpreted: string;
+  columns: string[];
+  rows: Record<string, unknown>[];
+  rowCount: number;
+  csv: string;
+}
+
+const EXAMPLES = [
+  "Show all wells in Livingston County",
+  "Wells in Jackson County deeper than 4000 feet",
+  "Wells completed after 2010",
+  "Injection wells with H2S present",
+];
+
+export default function QueryPage() {
+  const [question, setQuestion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<QueryData | null>(null);
+
+  const run = async (q: string) => {
+    const text = q.trim();
+    if (!text) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiClient.nlQuery(text);
+      if (res.status === "success" && res.data) {
+        setData(res.data as QueryData);
+      } else {
+        setError(res.message || "Query failed");
+        setData(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Query failed");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const downloadCsv = () => {
+    if (!data) return;
+    const blob = new Blob([data.csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "query-results.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const tableColumns = (data?.columns ?? []).map((c) => ({
+    title: c,
+    dataIndex: c,
+    key: c,
+    render: (v: unknown) => (v === null || v === undefined ? "" : String(v)),
+  }));
+  const tableRows = (data?.rows ?? []).map((r, i) => ({ key: i, ...r }));
+
+  return (
+    <ProtectedRoute>
+      <SidebarLayout>
+        <div style={{ maxWidth: 1100, margin: "0 auto", padding: 24 }}>
+          <Title level={3}>Ask your data</Title>
+          <Paragraph type="secondary">
+            Ask a question in plain English about your well records. Results come back as a table you can export.
+          </Paragraph>
+
+          <Input.Search
+            placeholder="e.g. Wells in Jackson County deeper than 4000 feet"
+            enterButton={<><Search size={16} style={{ marginRight: 6 }} /> Ask</>}
+            size="large"
+            value={question}
+            loading={loading}
+            onChange={(e) => setQuestion(e.target.value)}
+            onSearch={run}
+          />
+
+          <Space size={[8, 8]} wrap style={{ marginTop: 12 }}>
+            <Text type="secondary">Try:</Text>
+            {EXAMPLES.map((ex) => (
+              <Tag
+                key={ex}
+                style={{ cursor: "pointer" }}
+                onClick={() => { setQuestion(ex); run(ex); }}
+              >
+                {ex}
+              </Tag>
+            ))}
+          </Space>
+
+          {error && <Alert style={{ marginTop: 16 }} type="error" showIcon message={error} />}
+
+          {data && (
+            <Card style={{ marginTop: 16 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+                <div>
+                  {/* The interpreted-filter echo — what was actually searched. */}
+                  <Tag color="blue">{data.interpreted}</Tag>
+                  <Text type="secondary" style={{ marginLeft: 8 }}>{data.rowCount} records</Text>
+                </div>
+                <Button icon={<Download size={16} />} onClick={downloadCsv} disabled={!data.rowCount}>
+                  Export CSV
+                </Button>
+              </div>
+              {data.rowCount === 0 ? (
+                <Empty description="No records matched" />
+              ) : (
+                <Table
+                  columns={tableColumns}
+                  dataSource={tableRows}
+                  size="small"
+                  scroll={{ x: true }}
+                  pagination={{ pageSize: 25, showSizeChanger: true }}
+                />
+              )}
+            </Card>
+          )}
+        </div>
+      </SidebarLayout>
+    </ProtectedRoute>
+  );
+}

--- a/src/components/nlquery/AiChatPanel.tsx
+++ b/src/components/nlquery/AiChatPanel.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, Input, Table, Tag, Alert, Spin, Tooltip } from "antd";
+import { Send, Download, Sparkles, X } from "lucide-react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  apiClient,
+  type NlChatScope,
+  type NlChatView,
+  type NlChatResultSummary,
+} from "@/lib/api";
+
+// The agent replies in GitHub-flavoured markdown (headers, **bold**, tables).
+// Render it compactly to fit the chat bubble rather than showing raw syntax.
+const mdComponents: Components = {
+  p: ({ ...p }) => <p className="mb-2 leading-relaxed last:mb-0" {...p} />,
+  strong: ({ ...p }) => <strong className="font-semibold" {...p} />,
+  h1: ({ ...p }) => <h1 className="mb-1 mt-2 text-[13px] font-semibold" {...p} />,
+  h2: ({ ...p }) => <h2 className="mb-1 mt-2 text-[13px] font-semibold" {...p} />,
+  h3: ({ ...p }) => <h3 className="mb-1 mt-2 text-[13px] font-semibold" {...p} />,
+  ul: ({ ...p }) => <ul className="mb-2 list-disc space-y-0.5 pl-4" {...p} />,
+  ol: ({ ...p }) => <ol className="mb-2 list-decimal space-y-0.5 pl-4" {...p} />,
+  li: ({ ...p }) => <li className="leading-snug" {...p} />,
+  a: ({ ...p }) => (
+    <a className="text-violet-600 underline" target="_blank" rel="noreferrer" {...p} />
+  ),
+  hr: ({ ...p }) => <hr className="my-2 border-gray-200" {...p} />,
+  code: ({ ...p }) => (
+    <code className="rounded bg-gray-200 px-1 py-0.5 text-[12px]" {...p} />
+  ),
+  blockquote: ({ ...p }) => (
+    <blockquote className="mb-2 border-l-2 border-gray-300 pl-2 text-gray-600" {...p} />
+  ),
+  table: ({ ...p }) => (
+    <div className="mb-2 overflow-x-auto">
+      <table className="w-full border-collapse text-[12px]" {...p} />
+    </div>
+  ),
+  th: ({ ...p }) => (
+    <th className="border border-gray-300 bg-gray-50 px-2 py-1 text-left font-semibold" {...p} />
+  ),
+  td: ({ ...p }) => <td className="border border-gray-200 px-2 py-1 align-top" {...p} />,
+};
+
+function MarkdownMessage({ content }: { content: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+      {content}
+    </ReactMarkdown>
+  );
+}
+
+/** A message as rendered in the panel. `view` is the detail table the agent rendered. */
+interface UiMessage {
+  role: "user" | "assistant";
+  content: string;
+  view?: NlChatView | null;
+  resultSummary?: NlChatResultSummary | null;
+  error?: boolean;
+}
+
+interface AiChatPanelProps {
+  /** Structural scope this chat is bound to (preview / file / record / slug). */
+  scope: NlChatScope;
+  /** Header title — usually the same context label as the launching button. */
+  title?: string;
+  onClose?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+function DetailTable({ view }: { view: NlChatView }) {
+  const columns = view.columns.map((c) => ({
+    title: c,
+    dataIndex: c,
+    key: c,
+    render: (v: unknown) => (v === null || v === undefined ? "" : String(v)),
+  }));
+  const rows = view.rows.map((r, i) => ({ key: i, ...r }));
+
+  const downloadCsv = () => {
+    const blob = new Blob([view.csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "query-results.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="mt-2 rounded-md border border-gray-200 bg-white">
+      <div className="flex items-center justify-between px-2 py-1.5">
+        <span className="text-xs text-gray-500">{view.rowCount} records</span>
+        <Button size="small" icon={<Download size={13} />} onClick={downloadCsv} disabled={!view.rowCount}>
+          CSV
+        </Button>
+      </div>
+      <Table
+        columns={columns}
+        dataSource={rows}
+        size="small"
+        scroll={{ x: true, y: 240 }}
+        pagination={view.rowCount > 25 ? { pageSize: 25, size: "small" } : false}
+      />
+    </div>
+  );
+}
+
+const AiChatPanel: React.FC<AiChatPanelProps> = ({ scope, title, onClose, className, style }) => {
+  const [messages, setMessages] = useState<UiMessage[]>([]);
+  const [starters, setStarters] = useState<string[]>([]);
+  const [scopeLabel, setScopeLabel] = useState<string>("");
+  const [recordCount, setRecordCount] = useState<number | null>(null);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Re-load whenever the bound scope changes (a different file/record/type).
+  const scopeKey = useMemo(() => JSON.stringify(scope), [scope]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingHistory(true);
+    setError(null);
+    apiClient
+      .nlChatHistory(scope)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.status === "success" && res.data) {
+          setScopeLabel(res.data.scopeLabel);
+          setRecordCount(res.data.recordCount);
+          setStarters(res.data.starters ?? []);
+          setMessages(
+            (res.data.messages ?? []).map((m) => ({
+              role: m.role,
+              content: m.content ?? "",
+              resultSummary: m.resultSummary,
+            })),
+          );
+        } else {
+          setError(res.message || "Could not load this conversation.");
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Could not load this conversation.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingHistory(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeKey]);
+
+  // Keep the latest message in view.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, sending]);
+
+  const send = useCallback(
+    async (raw: string) => {
+      const question = raw.trim();
+      if (!question || sending) return;
+      setInput("");
+      setError(null);
+      setMessages((prev) => [...prev, { role: "user", content: question }]);
+      setSending(true);
+      try {
+        const res = await apiClient.nlChat(question, scope);
+        if (res.status === "success" && res.data) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "assistant",
+              content: res.data!.reply,
+              view: res.data!.view,
+              resultSummary: res.data!.resultSummary,
+            },
+          ]);
+        } else {
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: res.message || "Something went wrong.", error: true },
+          ]);
+        }
+      } catch (e) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: e instanceof Error ? e.message : "Something went wrong.",
+            error: true,
+          },
+        ]);
+      } finally {
+        setSending(false);
+      }
+    },
+    [scope, sending],
+  );
+
+  const hasConversation = messages.length > 0;
+
+  return (
+    <div className={`flex h-full min-h-0 flex-col bg-white ${className ?? ""}`} style={style}>
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2 border-b border-gray-200 px-3 py-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 text-sm font-semibold text-gray-800">
+            <Sparkles size={15} className="text-violet-500" />
+            <span className="truncate">{title || "Ask AI"}</span>
+          </div>
+          {scopeLabel && (
+            <div className="truncate text-xs text-gray-400">
+              {scopeLabel}
+              {recordCount != null && ` · ${recordCount} records`}
+            </div>
+          )}
+        </div>
+        {onClose && (
+          <Tooltip title="Close">
+            <Button type="text" size="small" icon={<X size={15} />} onClick={onClose} />
+          </Tooltip>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto px-3 py-3">
+        {loadingHistory ? (
+          <div className="flex h-full items-center justify-center">
+            <Spin />
+          </div>
+        ) : (
+          <>
+            {!hasConversation && (
+              <div className="text-sm text-gray-500">
+                Ask a question about {scopeLabel || "this data"} in plain English.
+              </div>
+            )}
+
+            {messages.map((m, i) => (
+              <div key={i} className={m.role === "user" ? "flex justify-end" : "flex justify-start"}>
+                <div className={m.role === "user" ? "max-w-[85%]" : "max-w-[95%]"}>
+                  {m.role === "assistant" && !m.error ? (
+                    <div className="rounded-2xl rounded-bl-sm bg-gray-100 px-3 py-2 text-sm text-gray-800">
+                      <MarkdownMessage content={m.content} />
+                    </div>
+                  ) : (
+                    <div
+                      className={
+                        m.role === "user"
+                          ? "rounded-2xl rounded-br-sm bg-violet-600 px-3 py-2 text-sm text-white"
+                          : "rounded-2xl rounded-bl-sm bg-red-50 px-3 py-2 text-sm text-red-700"
+                      }
+                      style={{ whiteSpace: "pre-wrap" }}
+                    >
+                      {m.content}
+                    </div>
+                  )}
+                  {m.view && <DetailTable view={m.view} />}
+                </div>
+              </div>
+            ))}
+
+            {sending && (
+              <div className="flex justify-start">
+                <div className="rounded-2xl rounded-bl-sm bg-gray-100 px-3 py-2 text-sm text-gray-400">
+                  <Spin size="small" /> <span className="ml-1">Thinking…</span>
+                </div>
+              </div>
+            )}
+
+            {/* Starter chips, only before the conversation begins. */}
+            {!hasConversation && starters.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                {starters.map((s) => (
+                  <Tag
+                    key={s}
+                    className="cursor-pointer"
+                    style={{ borderRadius: 999, padding: "3px 10px", margin: 0 }}
+                    onClick={() => send(s)}
+                  >
+                    {s}
+                  </Tag>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {error && <Alert type="error" showIcon message={error} className="mx-3" />}
+
+      {/* Composer */}
+      <div className="border-t border-gray-200 p-2">
+        <Input.TextArea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask a question…"
+          autoSize={{ minRows: 1, maxRows: 4 }}
+          disabled={loadingHistory}
+          onPressEnter={(e) => {
+            if (!e.shiftKey) {
+              e.preventDefault();
+              send(input);
+            }
+          }}
+        />
+        <div className="mt-1.5 flex justify-end">
+          <Button
+            type="primary"
+            size="small"
+            icon={<Send size={14} />}
+            loading={sending}
+            disabled={!input.trim() || loadingHistory}
+            onClick={() => send(input)}
+          >
+            Send
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AiChatPanel;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -623,6 +623,59 @@ export interface PreviewAnalyticsReport {
     }>;
 }
 
+// ── NL-query conversational chat ──────────────────────────────────────────
+/** Structural scope a chat is bound to (mirrors the backend's resolveScope input). */
+export interface NlChatScope {
+    slug?: string;
+    fileId?: string;
+    jobId?: string;
+    previewId?: string;
+    recordId?: string;
+    sectionKey?: string;
+}
+
+export interface NlChatResultSummary {
+    mode: "list" | "aggregate";
+    rowCount?: number;
+    summaryRows?: Record<string, unknown>[];
+    sample: Record<string, unknown>[];
+}
+
+/** The detail table the agent renders when the user asks to see/export the list. */
+export interface NlChatView {
+    interpreted: string;
+    columns: string[];
+    rows: Record<string, unknown>[];
+    rowCount: number;
+    csv: string;
+}
+
+export interface NlChatMessage {
+    id: string;
+    role: "user" | "assistant";
+    content: string | null;
+    resultSummary: NlChatResultSummary | null;
+    renderedView: boolean;
+    createdAt: string;
+}
+
+export interface NlChatHistory {
+    conversationId: string | null;
+    slug: string;
+    scopeLabel: string;
+    recordCount: number;
+    starters: string[];
+    messages: NlChatMessage[];
+}
+
+export interface NlChatTurn {
+    conversationId: string;
+    reply: string;
+    resultSummary: NlChatResultSummary | null;
+    renderView: boolean;
+    view: NlChatView | null;
+}
+
 class ApiClient {
     private baseURL: string;
     private accessToken: string | null = null;
@@ -2136,6 +2189,25 @@ class ApiClient {
         return this.request('/nlquery', {
             method: 'POST',
             body: JSON.stringify({ question, slug, ...opts }),
+        });
+    }
+
+    // Load the chat for a scope (history + scope-aware starter questions) without
+    // creating a conversation. Drives the chat panel's first render.
+    async nlChatHistory(scope: NlChatScope): Promise<ApiResponse<NlChatHistory>> {
+        const params = new URLSearchParams();
+        Object.entries(scope).forEach(([k, v]) => {
+            if (v) params.set(k, String(v));
+        });
+        return this.request(`/nlquery/chat?${params.toString()}`, { method: 'GET' });
+    }
+
+    // One conversational turn over the records in scope.
+    async nlChat(question: string, scope: NlChatScope): Promise<ApiResponse<NlChatTurn>> {
+        const { slug, ...rest } = scope;
+        return this.request('/nlquery/chat', {
+            method: 'POST',
+            body: JSON.stringify({ question, slug, scope: rest }),
         });
     }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2119,6 +2119,25 @@ class ApiClient {
             body: JSON.stringify({ fileIds, priority, processingConfig }),
         });
     }
+
+    // Natural-language query over extracted data → table + interpreted filter.
+    async nlQuery(
+        question: string,
+        slug: string = 'mgs_well_log',
+        opts: { jobId?: string; orgId?: string } = {}
+    ): Promise<ApiResponse<{
+        interpreted: string;
+        spec: unknown;
+        columns: string[];
+        rows: Record<string, unknown>[];
+        rowCount: number;
+        csv: string;
+    }>> {
+        return this.request('/nlquery', {
+            method: 'POST',
+            body: JSON.stringify({ question, slug, ...opts }),
+        });
+    }
 }
 
 // Create singleton instance


### PR DESCRIPTION
The web UI for natural-language chat over extracted data. Pairs with the backend PR in the `ai` repo (`POST`/`GET /nlquery/chat`).

## What's here
- **`AiChatPanel`** (`src/components/nlquery/AiChatPanel.tsx`): reusable chat panel — message list, scope-aware starter-question chips, composer, `render_view` detail table with CSV export, and markdown-rendered assistant replies (react-markdown + remark-gfm, since the agent emits tables/headers). Loads conversation history on open.
- **api client** (`src/lib/api.ts`): `NlChatScope/View/Message/History/Turn` types + `nlChatHistory()` / `nlChat()`.
- **preview page** (`src/app/preview/[id]/page.tsx`): two entry points —
  - footer button with **dynamic copy** per left-rail view: *Ask about all records* / *Ask about {document type}* / *Ask about all files* / *Ask about {filename}*.
  - **Ask AI** button in the record drawer, next to Compare.
  - Panel is resizable via antd `Splitter`. When both Compare and AI are open, the drawer goes full-width and squeezes into a 3-way **[PDF · record · AI]** split rather than making them mutually exclusive.
- Entry points are **gated on auth** — the preview page is public, but chat is authed + org-scoped.

## Also includes
The lean standalone `/query` page + `apiClient.nlQuery()` (one-shot NL query → table), from earlier in the effort.

## Verification
Driven live in the browser (logged-in, prod data) across all four preview contexts and the record-drawer Compare+AI squeeze: dynamic button copy, data-aware starters, grounded replies, render_view table + CSV, history persist/reload. `tsc` clean apart from a pre-existing unrelated `Button.tsx` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)