### PR TITLE
QA findings: apply flow for row-level fixes, typed corrected_value, QA-hints admin tab

### DIFF
--- a/src/components/registry/SchemaRegistryAdmin.tsx
+++ b/src/components/registry/SchemaRegistryAdmin.tsx
@@ -50,6 +50,21 @@ const CLASSIFIER_HINTS_PLACEHOLDER = `{
   ]
 }`;
 
+/** Shown when the QA hints editor is empty; keyed by top-level schema field-group name. */
+const QA_HINTS_PLACEHOLDER = `{
+  "lithology_intervals": {
+    "priority": "critical",
+    "notes": "Verify every depth_from_ft/depth_to_ft and primary_material against the log column — this is what reviewers care about most."
+  },
+  "document_metadata": {
+    "priority": "low",
+    "ignore": ["total_pages", "page_number"]
+  },
+  "extraction_metadata": {
+    "skip": true
+  }
+}`;
+
 export default function SchemaRegistryAdmin() {
   const { message } = App.useApp();
   const [loading, setLoading] = useState(true);
@@ -64,6 +79,7 @@ export default function SchemaRegistryAdmin() {
   const [versions, setVersions] = useState<RegistrySchemaVersionSummary[]>([]);
   const [editForm] = Form.useForm();
   const [hintsText, setHintsText] = useState("");
+  const [qaHintsText, setQaHintsText] = useState("");
   // Post-processing defaults for the managed slug: registered services + the
   // per-service enabled map (name → enabled) seeded from the document type.
   const [ppServices, setPpServices] = useState<{ name: string; version: string }[]>([]);
@@ -125,6 +141,12 @@ export default function SchemaRegistryAdmin() {
       setHintsText(
         res.documentType.classifier_hints
           ? JSON.stringify(res.documentType.classifier_hints, null, 2)
+          : "",
+      );
+      setQaHintsText(
+        res.documentType.qa_hints &&
+          Object.keys(res.documentType.qa_hints).length > 0
+          ? JSON.stringify(res.documentType.qa_hints, null, 2)
           : "",
       );
       // Seed post-processing defaults (name → enabled) from the document type.
@@ -222,6 +244,39 @@ export default function SchemaRegistryAdmin() {
       } else message.error(res.message || "Save failed");
     } catch {
       message.error("Invalid JSON in classifier hints");
+    }
+  };
+
+  const saveQAHints = async () => {
+    if (!manageSlug) return;
+    const trimmed = qaHintsText.trim();
+    if (!trimmed) {
+      const res = await apiClient.registryPutQAHints(manageSlug, null);
+      if (res.success) {
+        message.success("QA hints cleared");
+        openManage(manageSlug);
+        loadTypes();
+      } else message.error(res.message || "Clear failed");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        message.error("Hints must be a JSON object");
+        return;
+      }
+      const res = await apiClient.registryPutQAHints(manageSlug, parsed);
+      if (res.success) {
+        message.success("QA hints saved");
+        openManage(manageSlug);
+        loadTypes();
+      } else message.error(res.message || "Save failed");
+    } catch {
+      message.error("Invalid JSON in QA hints");
     }
   };
 
@@ -362,9 +417,14 @@ export default function SchemaRegistryAdmin() {
       ),
     },
     {
-      title: "Hints",
+      title: "Classifier hints",
       key: "hints",
       render: (_, r) => <Tag>{r.has_classifier_hints ? "Yes" : "No"}</Tag>,
+    },
+    {
+      title: "QA hints",
+      key: "qa_hints",
+      render: (_, r) => <Tag>{r.has_qa_hints ? "Yes" : "No"}</Tag>,
     },
     {
       title: "",
@@ -664,6 +724,42 @@ export default function SchemaRegistryAdmin() {
                     />
                     <Space>
                       <Button type="primary" onClick={saveHints}>
+                        Save hints
+                      </Button>
+                    </Space>
+                  </div>
+                ),
+              },
+              {
+                key: "qa_hints",
+                label: "QA hints",
+                children: (
+                  <div className="space-y-3 pt-2">
+                    <Paragraph type="secondary" className="!text-xs">
+                      Per-field-group review priority for post-extraction QA,
+                      keyed by top-level schema property name (e.g.
+                      lithology_intervals, document_metadata). Set
+                      priority (critical/high/normal/low), fields to never
+                      flag, and free-text notes. Leave empty and save to clear.
+                    </Paragraph>
+                    <JsonViewer
+                      text={qaHintsText}
+                      onChange={({ text: t }) => setQaHintsText(t)}
+                      placeholder={QA_HINTS_PLACEHOLDER}
+                      defaultMode="code"
+                      mode="code"
+                      height={360}
+                      toolbar={[
+                        "mode",
+                        "format",
+                        "minify",
+                        "search",
+                        "copy",
+                        "upload",
+                      ]}
+                    />
+                    <Space>
+                      <Button type="primary" onClick={saveQAHints}>
                         Save hints
                       </Button>
                     </Space>

--- a/src/components/ui/TabbedDataViewer.tsx
+++ b/src/components/ui/TabbedDataViewer.tsx
@@ -11,6 +11,8 @@ import {
   getByPath,
   setByPath,
   coerceExpected,
+  insertAtPath,
+  removeAtPath,
   APPLYABLE_ISSUE_TYPES,
 } from "@/lib/jsonPath";
 import {
@@ -323,9 +325,22 @@ function QAFindingsPanel({
     }
   };
 
+  const ROW_ISSUE_TYPES = new Set(["add_row", "update_row", "delete_row"]);
+
   const renderFinding = (f: import("@/lib/api").QAFinding) => {
     const cfg = SEVERITY_CONFIG[f.severity] ?? SEVERITY_CONFIG.info;
     const isResolved = f.status !== "open";
+    const isRowOp = ROW_ISSUE_TYPES.has(f.issue_type);
+    const rowOpLabel =
+      f.issue_type === "delete_row"
+        ? `Delete row ${f.row_index ?? "?"}`
+        : f.issue_type === "add_row"
+          ? f.row_index != null
+            ? `Insert row at ${f.row_index}`
+            : "Insert row"
+          : f.issue_type === "update_row"
+            ? `Replace row ${f.row_index ?? "?"}`
+            : "Apply";
     return (
       <div
         key={f.id}
@@ -342,18 +357,48 @@ function QAFindingsPanel({
                 {f.issue_type.replace(/_/g, " ")}
               </span>
             </div>
-            {(f.expected || f.actual) && (
+            {(f.expected || f.actual || f.corrected_value !== undefined) && (
               <div className="mt-1 text-xs text-gray-600 space-y-0.5">
                 {f.expected && (
                   <div>
                     <span className="font-medium">Expected:</span> {f.expected}
                   </div>
                 )}
-                {f.actual && (
+                {f.actual && !isRowOp && (
                   <div>
                     <span className="font-medium">Actual:</span> {f.actual}
                   </div>
                 )}
+                {f.corrected_value !== undefined && f.corrected_value !== null && (
+                  <div>
+                    <span className="font-medium">Correction:</span>{" "}
+                    {JSON.stringify(f.corrected_value)}
+                  </div>
+                )}
+              </div>
+            )}
+            {isRowOp && f.actual && (
+              <div className="mt-1">
+                <span className="text-xs font-medium text-gray-600">
+                  {f.issue_type === "delete_row" ? "Row to remove:" : "Current row:"}
+                </span>
+                <pre className="mt-0.5 text-xs bg-white/60 border border-gray-200 rounded px-2 py-1 overflow-x-auto max-w-full">
+                  {(() => {
+                    try {
+                      return JSON.stringify(JSON.parse(f.actual), null, 2);
+                    } catch {
+                      return f.actual;
+                    }
+                  })()}
+                </pre>
+              </div>
+            )}
+            {isRowOp && f.row_value && (
+              <div className="mt-1">
+                <span className="text-xs font-medium text-gray-600">Proposed row:</span>
+                <pre className="mt-0.5 text-xs bg-white/60 border border-gray-200 rounded px-2 py-1 overflow-x-auto max-w-full">
+                  {JSON.stringify(f.row_value, null, 2)}
+                </pre>
               </div>
             )}
             <p className="mt-1 text-xs text-gray-500 italic">{f.explanation}</p>
@@ -362,13 +407,33 @@ function QAFindingsPanel({
             <div className="flex gap-1 flex-shrink-0">
               {canApply && APPLYABLE_ISSUE_TYPES.has(f.issue_type) && (
                 <>
-                  <button
-                    onClick={() => onApply(f)}
-                    className="text-xs text-blue-700 font-medium hover:underline"
-                    title={`Set ${f.field_path} = ${f.issue_type === "extra_value" ? "null" : (f.expected ?? "null")}`}
-                  >
-                    Apply
-                  </button>
+                  {isRowOp ? (
+                    <Popconfirm
+                      title={rowOpLabel}
+                      description={`This changes ${f.field_path}'s row count/order — review the result in the JSON tree before Saving.`}
+                      okText={rowOpLabel}
+                      cancelText="Cancel"
+                      onConfirm={() => onApply(f)}
+                    >
+                      <button className="text-xs text-blue-700 font-medium hover:underline">
+                        {rowOpLabel}
+                      </button>
+                    </Popconfirm>
+                  ) : (
+                    <button
+                      onClick={() => onApply(f)}
+                      className="text-xs text-blue-700 font-medium hover:underline"
+                      title={`Set ${f.field_path} = ${
+                        f.issue_type === "extra_value"
+                          ? "null"
+                          : f.corrected_value !== undefined
+                            ? JSON.stringify(f.corrected_value)
+                            : (f.expected ?? "null")
+                      }`}
+                    >
+                      Apply
+                    </button>
+                  )}
                   <span className="text-gray-300">|</span>
                 </>
               )}
@@ -1161,18 +1226,80 @@ const TabbedDataViewer: React.FC<TabbedDataViewerProps> = ({
     ? currentSectionMarkdown?.pages ?? []
     : pages;
 
-  // Inject a finding's "right answer" (expected) into the editable JSON at its
-  // field_path. The user reviews the change in the tree and Saves to persist
-  // (via the existing per-record PATCH). extra_value (hallucination) → set null.
+  // Inject a finding's correct answer into the editable JSON. The user
+  // reviews the change in the tree and Saves to persist (via the existing
+  // per-record PATCH) — this never writes directly to the server.
+  // Row-level ops (add_row/update_row/delete_row) mutate the array at
+  // field_path using row_index/row_value; everything else writes a single
+  // scalar at field_path. extra_value (hallucination) → set null. Prefer the
+  // typed `corrected_value` when present for scalars — it's the model's
+  // actual typed answer (e.g. a real boolean true/false), not a string quote
+  // of page evidence that may not coerce cleanly (coerceExpected is a
+  // best-effort fallback for findings saved before corrected_value existed).
   const handleApplyFinding = useCallback(
     (finding: import("@/lib/api").QAFinding) => {
       try {
         const parsed = JSON.parse(editableJson);
+
+        if (finding.issue_type === "delete_row") {
+          if (finding.row_index == null) {
+            throw new Error("missing row_index for delete_row");
+          }
+          const updated = removeAtPath(
+            parsed,
+            finding.field_path,
+            finding.row_index,
+          );
+          setEditableJson(JSON.stringify(updated, null, 2));
+          setJsonError(null);
+          message.success(
+            `Removed ${finding.field_path}[${finding.row_index}] — review and Save to persist`,
+          );
+          return;
+        }
+
+        if (finding.issue_type === "add_row" || finding.issue_type === "update_row") {
+          if (!finding.row_value) {
+            throw new Error("missing row_value");
+          }
+          const updated =
+            finding.issue_type === "add_row"
+              ? insertAtPath(
+                  parsed,
+                  finding.field_path,
+                  finding.row_index,
+                  finding.row_value,
+                )
+              : setByPath(
+                  parsed,
+                  `${finding.field_path}[${finding.row_index}]`,
+                  finding.row_value,
+                );
+          setEditableJson(JSON.stringify(updated, null, 2));
+          setJsonError(null);
+          message.success(
+            `${finding.issue_type === "add_row" ? "Inserted" : "Replaced"} a row in ${finding.field_path} — review and Save to persist`,
+          );
+          return;
+        }
+
         const current = getByPath(parsed, finding.field_path);
+        // A SQL NULL always comes back as JS `null` (never `undefined`) once
+        // it's crossed the DB/API boundary — so `null` here doesn't mean "the
+        // model answered null", it means "no usable corrected_value" (an
+        // older finding saved before this column existed, or the model
+        // genuinely didn't provide one). Only trust corrected_value when it's
+        // a real, non-null value; otherwise fall back to the text-based
+        // coercion exactly like before this field existed. Mirrors the same
+        // `!== null` check already used server-side in verifyFindingAgainstRecord.
+        const hasCorrectedValue =
+          finding.corrected_value !== undefined && finding.corrected_value !== null;
         const newValue =
           finding.issue_type === "extra_value"
             ? null
-            : coerceExpected(finding.expected, current);
+            : hasCorrectedValue
+              ? finding.corrected_value
+              : coerceExpected(finding.expected, current);
         const updated = setByPath(parsed, finding.field_path, newValue);
         setEditableJson(JSON.stringify(updated, null, 2));
         setJsonError(null);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -247,6 +247,7 @@ export interface DocumentTypeInfo {
     routing_confidence_threshold?: number | null;
     status: 'active' | 'deprecated' | string;
     has_classifier_hints: boolean;
+    has_qa_hints: boolean;
 }
 
 // Admin schema registry (GET /registry/...)
@@ -258,6 +259,7 @@ export interface RegistryDocumentTypeDetail {
     routing_confidence_threshold: number;
     status: string;
     classifier_hints?: Record<string, unknown> | null;
+    qa_hints?: Record<string, unknown> | null;
     post_processing_defaults?: PostProcessingOverride[] | null;
     identifier_fields?: string[] | null;
     created_at?: string;
@@ -346,7 +348,7 @@ export interface DetectedSections {
 
 // ── Section QA findings ──────────────────────────────────────────────
 
-export type QAIssueType = 'wrong_value' | 'missing_value' | 'extra_value' | 'missing_rows' | 'extra_rows' | 'wrong_count' | 'formatting';
+export type QAIssueType = 'wrong_value' | 'missing_value' | 'extra_value' | 'missing_rows' | 'extra_rows' | 'wrong_count' | 'formatting' | 'add_row' | 'update_row' | 'delete_row';
 export type QASeverity = 'error' | 'warning' | 'info';
 export type QAFindingStatus = 'open' | 'accepted' | 'dismissed';
 export type QAOverallQuality = 'perfect' | 'good' | 'acceptable' | 'poor';
@@ -360,6 +362,27 @@ export interface QAFinding {
     severity: QASeverity;
     expected: string | null;
     actual: string | null;
+    /**
+     * Typed replacement value for `actual` (string/number/boolean/null),
+     * distinct from `expected` which is a verbatim evidence quote and may not
+     * be directly injectable (e.g. a boolean field's evidence is often a
+     * marker/note, not the literal word "true"/"false"). Absent (undefined)
+     * on findings saved before this field existed — fall back to
+     * coerceExpected(expected, ...) in that case.
+     */
+    corrected_value?: string | number | boolean | null;
+    /**
+     * 0-indexed position within the target array (which must itself be
+     * `field_path`). Required for delete_row/update_row; optional insertion
+     * position for add_row (null/undefined = append). Null/undefined for
+     * every other issue_type.
+     */
+    row_index?: number | null;
+    /**
+     * Full row object for add_row/update_row, matching the target array's
+     * item shape. Null/undefined for delete_row and every other issue_type.
+     */
+    row_value?: Record<string, unknown> | null;
     explanation: string;
     status: QAFindingStatus;
     overall_quality: QAOverallQuality | null;
@@ -1019,6 +1042,17 @@ class ApiClient {
         hints: Record<string, unknown> | null
     ): Promise<ApiResponse<{ classifier_hints: unknown; updated_at: string }>> {
         return this.request(`/registry/document-types/${encodeURIComponent(slug)}/classifier-hints`, {
+            method: 'PUT',
+            body: JSON.stringify({ hints }),
+        });
+    }
+
+    /** Per-field-group QA review priority/ignore guidance, keyed by top-level schema property name. null clears. */
+    async registryPutQAHints(
+        slug: string,
+        hints: Record<string, unknown> | null
+    ): Promise<ApiResponse<{ qa_hints: unknown; updated_at: string }>> {
+        return this.request(`/registry/document-types/${encodeURIComponent(slug)}/qa-hints`, {
             method: 'PUT',
             body: JSON.stringify({ hints }),
         });

--- a/src/lib/jsonPath.ts
+++ b/src/lib/jsonPath.ts
@@ -77,4 +77,51 @@ export const APPLYABLE_ISSUE_TYPES = new Set([
   "missing_value",
   "extra_value",
   "formatting",
+  "add_row",
+  "update_row",
+  "delete_row",
 ]);
+
+/**
+ * Immutably insert `value` into the array at `arrayPath`, at `index` (or
+ * appended at the end when `index` is null/undefined/out of range). Used for
+ * add_row findings — distinct from setByPath, which overwrites a single slot
+ * rather than shifting subsequent items.
+ */
+export function insertAtPath<T>(
+  obj: T,
+  arrayPath: string,
+  index: number | null | undefined,
+  value: unknown,
+): T {
+  const clone: any = structuredClone(obj);
+  const segs = parsePath(arrayPath);
+  let cur: any = clone;
+  for (let i = 0; i < segs.length - 1; i++) {
+    const seg = segs[i];
+    if (cur[seg] == null || typeof cur[seg] !== "object") cur[seg] = [];
+    cur = cur[seg];
+  }
+  const lastSeg = segs[segs.length - 1];
+  if (!Array.isArray(cur[lastSeg])) cur[lastSeg] = [];
+  const arr = cur[lastSeg] as unknown[];
+  const insertAt =
+    index == null || index < 0 || index > arr.length ? arr.length : index;
+  arr.splice(insertAt, 0, value);
+  return clone;
+}
+
+/**
+ * Immutably remove the item at `index` from the array at `arrayPath`. Used
+ * for delete_row findings. No-op (returns an unmodified clone) if the target
+ * isn't an array or the index is out of range — callers should already have
+ * verified the index server-side, but this stays defensive against a stale
+ * client-side tree.
+ */
+export function removeAtPath<T>(obj: T, arrayPath: string, index: number): T {
+  const clone: any = structuredClone(obj);
+  const arr = getByPath(clone, arrayPath);
+  if (!Array.isArray(arr) || index < 0 || index >= arr.length) return clone;
+  arr.splice(index, 1);
+  return clone;
+}


### PR DESCRIPTION
Companion to ai repo PR [#52](https://github.com/Ayobamiu/text-to-structured-data/pull/52) (per-group section QA overhaul).

## What this does

- **`QAFinding` type**: adds `corrected_value` (typed applyable answer — string/number/boolean/null — distinct from the verbatim page-evidence quote in `expected`), `row_index`, `row_value`, and issue types `add_row`/`update_row`/`delete_row`.
- **Apply flow for row-level findings**: `insertAtPath`/`removeAtPath` in `jsonPath.ts` (`update_row` reuses `setByPath`). Row ops get op-specific buttons ("Delete row 0" / "Insert row" / "Replace row 3") behind a Popconfirm since they change array length/order; the findings panel shows current/proposed row previews. Same review-in-JSON-tree-then-Save flow as scalar Apply — nothing auto-saves.
- **Apply correctness**: prefers `corrected_value` when present *and non-null*. A SQL NULL crossing the API means "no usable correction" (findings saved before the column existed), so Apply falls back to `coerceExpected(expected, current)` — treating null as "the answer is null" silently regressed Apply for all older findings once already.
- **SchemaRegistryAdmin**: new "QA hints" tab per document type (priority / ignore / notes / `skip: true` JSON per schema group, mirroring the classifier-hints editor) plus a `has_qa_hints` column in the type list.

## Verify

- `tsc --noEmit` clean (only the pre-existing `Button.tsx` framer-motion error remains).
- Manual: open a v2 file → section with QA findings → scalar Apply injects the typed correction; row-op Apply shows confirm + row preview, mutates the editable JSON, Save persists via the existing PATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)